### PR TITLE
Encypt and Decrypt Service refactor

### DIFF
--- a/field_encrypt.module
+++ b/field_encrypt.module
@@ -46,16 +46,33 @@ function field_encrypt_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $
  */
 function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\Entity\FieldStorageConfig $fieldStorageConfig, &$form, \Drupal\Core\Form\FormStateInterface $form_state) {
 
+  $form_encryption = $form_state->getValue('encrypt');
+  $original_encryption = $fieldStorageConfig->getThirdPartySetting('field_encrypt', 'encrypt');
+
   // If the form has the value, we set it.
-  if ($form_state->getValue('encrypt')) {
-    $fieldStorageConfig->setThirdPartySetting('field_encrypt', 'encrypt', $form_state->getValue('encrypt'));
-
-    // TODO: We need to process the field to either batch encrypt or batch decrypt if the setting was changed.
-
+  if ($form_encryption === 1) {
+    $fieldStorageConfig->setThirdPartySetting('field_encrypt', 'encrypt', $form_encryption);
   }
   else {
     // If there is no value, remove.
     $fieldStorageConfig->unsetThirdPartySetting('field_encrypt', 'encrypt');
+  }
+
+  if ($original_encryption !== $fieldStorageConfig->getThirdPartySetting('field_encrypt', 'encrypt')) {
+    // We need to process the field to either encrypt or decrypt the stored fields if the setting was changed.
+    $field_name = $fieldStorageConfig->get('field_name');
+    $field_entity_type = $fieldStorageConfig->get('entity_type');
+
+    /**
+     * @var $field_encrypt_process_entities \Drupal\field_encrypt\FieldEncryptProcessEntities
+     */
+    $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
+    if ($form_encryption === 1) {
+      $field_encrypt_process_entities->encrypt_stored_field($field_entity_type, $field_name);
+    }
+    elseif ($form_encryption === 0) {
+      $field_encrypt_process_entities->decrypt_stored_field($field_entity_type, $field_name);
+    }
   }
 }
 
@@ -66,8 +83,11 @@ function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\E
  */
 function field_encrypt_entity_presave(\Drupal\Core\Entity\EntityInterface $entity) {
   if (!($entity instanceof Drupal\Core\Entity\ContentEntityInterface)) {return;}
+  /**
+   * @var $field_encrypt_process_entities \Drupal\field_encrypt\FieldEncryptProcessEntities
+   */
   $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
-  $field_encrypt_process_entities->encrypt_fields($entity);
+  $field_encrypt_process_entities->encrypt_entity($entity);
 }
 
 /**
@@ -77,14 +97,13 @@ function field_encrypt_entity_presave(\Drupal\Core\Entity\EntityInterface $entit
  * @param $entity_type
  */
 function field_encrypt_entity_load($entities, $entity_type) {
+  /**
+   * @var $field_encrypt_process_entities \Drupal\field_encrypt\FieldEncryptProcessEntities
+   */
   $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
 
   foreach($entities as &$entity) {
     if (!($entity instanceof Drupal\Core\Entity\ContentEntityInterface)) {continue;}
-    $field_encrypt_process_entities->decrypt_fields($entity);
+    $field_encrypt_process_entities->decrypt_entity($entity);
   }
 }
-
-
-
-

--- a/field_encrypt.module
+++ b/field_encrypt.module
@@ -5,18 +5,20 @@
 
 /**
  * Implements hook_form_alter.
+ *
+ * Add a field to the field storage configuration forms to allow setting the encryption state.
  */
 function field_encrypt_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
 
   // If this is the add or edit form for field_storage, we call our function.
-  if ($form_id === 'field_storage_add_form' || $form_id === 'field_storage_config_edit_form') {
+  if (in_array($form_id, ['field_storage_add_form', 'field_storage_config_edit_form'])) {
 
     // Check permissions
     $user = \Drupal::currentUser();
 
     if ($user->hasPermission('administer field encryption')) {
       /**
-       * @var \Drupal\field\Entity\FieldStorageConfig
+       * @var $field \Drupal\field\Entity\FieldStorageConfig
        */
       $field = $form_state->getFormObject()->getEntity();
 
@@ -34,6 +36,14 @@ function field_encrypt_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $
   }
 }
 
+/**
+ * Update the field storage configuration to set the encryption state.
+ *
+ * @param $entity_type
+ * @param \Drupal\field\Entity\FieldStorageConfig $fieldStorageConfig
+ * @param $form
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ */
 function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\Entity\FieldStorageConfig $fieldStorageConfig, &$form, \Drupal\Core\Form\FormStateInterface $form_state) {
 
   // If the form has the value, we set it.
@@ -49,48 +59,32 @@ function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\E
   }
 }
 
+/**
+ * Encrypt fields before they are saved.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ */
 function field_encrypt_entity_presave(\Drupal\Core\Entity\EntityInterface $entity) {
-  field_encrypt_process_encrypted_fields($entity, 'encrypt');
+  if (!($entity instanceof Drupal\Core\Entity\ContentEntityInterface)) {return;}
+  $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
+  $field_encrypt_process_entities->encrypt_fields($entity);
 }
 
+/**
+ * Decrypt fields before they are rendered.
+ *
+ * @param $entities
+ * @param $entity_type
+ */
 function field_encrypt_entity_load($entities, $entity_type) {
+  $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
+
   foreach($entities as &$entity) {
-    field_encrypt_process_encrypted_fields($entity, 'decrypt');
+    if (!($entity instanceof Drupal\Core\Entity\ContentEntityInterface)) {continue;}
+    $field_encrypt_process_entities->decrypt_fields($entity);
   }
 }
 
-function field_encrypt_process_encrypted_fields(\Drupal\Core\Entity\EntityInterface $entity, $op = 'encrypt') {
-  // Make sure we can get field definitions.
-  if (!is_callable([$entity, 'getFieldDefinitions'])){return;}
-  if (!is_callable([$entity, 'getFields'])){return;}
-  //$entity->getFieldDefinitions();
-  $entity->getFields();
 
-  foreach($entity->getFieldDefinitions() as $name => $definition) {
-    if (!is_callable([$definition, 'get'])){continue;}
-
-    $storage = $definition->get('fieldStorage');
-    if (is_null($storage)) {continue;}
-
-    $encrypted = $storage->getThirdPartySetting('field_encrypt', 'encrypt', FALSE);
-
-    if ($encrypted) {
-      // Load the encyption service.
-      // @var \Drupal\encrypt\EncryptService
-      $encryption_service = Drupal::service('encryption');
-
-      if ($op === 'encrypt') {
-        $replacement = $encryption_service->encrypt($entity->get($name)->value);
-      }
-      elseif ($op === 'decrypt') {
-        $replacement = $encryption_service->decrypt($entity->get($name)->value);
-      }
-
-      // TODO: This code only works for basic fields. It does not correctly work for fields like the body which have markup in them.
-      $entity->set($name, $replacement, FALSE);
-
-    }
-  }
-}
 
 

--- a/field_encrypt.services.yml
+++ b/field_encrypt.services.yml
@@ -1,0 +1,4 @@
+services:
+  field_encrypt.process_entities:
+    class: Drupal\field_encrypt\FieldEncryptProcessEntities
+    arguments: ['@encryption']

--- a/field_encrypt.services.yml
+++ b/field_encrypt.services.yml
@@ -1,4 +1,4 @@
 services:
   field_encrypt.process_entities:
     class: Drupal\field_encrypt\FieldEncryptProcessEntities
-    arguments: ['@encryption']
+    arguments: ['@encryption', '@entity.query', '@entity.manager']

--- a/src/FieldEncryptProcessEntities.php
+++ b/src/FieldEncryptProcessEntities.php
@@ -273,6 +273,7 @@ class FieldEncryptProcessEntities {
 
     // The field is not null.
     $query->condition($field_name, NULL, '<>');
+    $query->allRevisions();
     $entity_ids = $query->execute();
 
     // Load entities.
@@ -281,11 +282,11 @@ class FieldEncryptProcessEntities {
      */
     $entity_storage = $this->entityManager->getStorage($entity_type);
 
-    foreach($entity_ids as $eid) {
+    foreach($entity_ids as $revision_id => $entity_id) {
       /**
        * @var $entity \Drupal\Core\Entity\Entity
        */
-      $entity = $entity_storage->load($eid);
+      $entity = $entity_storage->loadRevision($revision_id);
 
       /**
        * @var $field \Drupal\Core\Field\FieldItemList

--- a/src/FieldEncryptProcessEntities.php
+++ b/src/FieldEncryptProcessEntities.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * @file Contains \Drupal\field_encrypt\FieldEncryptProcessEntities
+ */
+
+namespace Drupal\field_encrypt;
+
+use Drupal\Core\Entity\EntityDefinitionUpdateManagerInterface;
+use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\encrypt\EncryptService;
+
+/**
+ *
+ */
+class FieldEncryptProcessEntities {
+
+  /**
+   * The entity manager.
+   *
+   * @var \Drupal\Core\Entity\EntityManagerInterface
+   */
+  protected $entityManager;
+
+  /**
+   * The entity definition update manager.
+   *
+   * @var \Drupal\Core\Entity\EntityDefinitionUpdateManagerInterface
+   */
+  protected $updateManager;
+
+  protected $encryptService;
+
+  /**
+   * Constructs an updates manager instance.
+   *
+   * @param \Drupal\Core\Entity\EntityManagerInterface $entity_manager
+   *   The entity manager.
+   * @param \Drupal\encrypt\EncryptService $encrypt_service
+   */
+  public function __construct(EntityManagerInterface $entity_manager, EncryptService $encrypt_service) {
+    $this->entityManager = $entity_manager;
+    $this->encryptService = $encrypt_service;
+  }
+
+  /**
+   * Encrypt fields for an entity.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   */
+  public function encrypt_fields(\Drupal\Core\Entity\ContentEntityInterface $entity) {
+    $this->process_fields($entity, 'encrypt');
+  }
+
+  /**
+   * Decrypt fields for an entity.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   */
+  public function decrypt_fields(\Drupal\Core\Entity\ContentEntityInterface $entity) {
+    $this->process_fields($entity, 'decrypt');
+  }
+
+  /**
+   * Process an entity to either encrypt or decrypt its fields.
+   *
+   * Both processes are very similar, so we bundle the field processing part.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   * @param string $op
+   */
+  protected function process_fields(\Drupal\Core\Entity\ContentEntityInterface $entity, $op = 'encrypt') {
+    // Make sure we can get field definitions.
+    if (!is_callable([$entity, 'getFieldDefinitions'])){return;}
+    if (!is_callable([$entity, 'getFields'])){return;}
+    //$entity->getFieldDefinitions();
+    $entity->getFields();
+
+    /**
+     * @var $definition \Drupal\Core\Field\FieldItemBase
+     */
+    foreach($entity->getFieldDefinitions() as $name => $definition) {
+      if (!is_callable([$definition, 'get'])){continue;}
+
+      /**
+       * @var $storage \Drupal\Core\Field\FieldConfigStorageBase
+       */
+      $storage = $definition->get('fieldStorage');
+      if (is_null($storage)) {continue;}
+
+      $encrypted = $storage->getThirdPartySetting('field_encrypt', 'encrypt', FALSE);
+
+      if ($encrypted) {
+        $replacement = '';
+
+        if ($op === 'encrypt') {
+          $replacement = $this->encryptService->encrypt($entity->get($name)->value);
+        }
+        elseif ($op === 'decrypt') {
+          $replacement = $this->encryptService->decrypt($entity->get($name)->value);
+        }
+
+        // TODO: This code only works for basic fields. It does not correctly work for fields like the body which have markup in them.
+        $entity->set($name, $replacement, FALSE);
+
+      }
+    }
+  }
+
+}

--- a/src/FieldEncryptProcessEntities.php
+++ b/src/FieldEncryptProcessEntities.php
@@ -5,6 +5,8 @@
 
 namespace Drupal\field_encrypt;
 
+use Drupal\Core\Entity\EntityManager;
+use Drupal\Core\Entity\Query\QueryFactory;
 use Drupal\encrypt\EncryptService;
 
 /**
@@ -55,6 +57,12 @@ class FieldEncryptProcessEntities {
   ];
 
   /**
+   * A flag to disable decryption if we are in the process of updating stored
+   * fields.
+   */
+  protected $updatingStoredField = 'none';
+
+  /**
    * Encryption service.
    *
    * @var \Drupal\encrypt\EncryptService
@@ -62,10 +70,28 @@ class FieldEncryptProcessEntities {
   protected $encryptService;
 
   /**
-   * @param \Drupal\encrypt\EncryptService $encrypt_service
+   * Query Factory
+   *
+   * @var \Drupal\Core\Entity\Query\QueryFactory
    */
-  public function __construct(EncryptService $encrypt_service) {
+  protected $queryFactory;
+
+  /**
+   * Entity Manager
+   *
+   * @var \Drupal\Core\Entity\EntityManager
+   */
+  protected $entityManager;
+
+  /**
+   * @param \Drupal\encrypt\EncryptService $encrypt_service
+   * @param \Drupal\Core\Entity\Query\QueryFactory $query_factory
+   * @param \Drupal\Core\Entity\EntityManager $entity_manager
+   */
+  public function __construct(EncryptService $encrypt_service, QueryFactory $query_factory, EntityManager $entity_manager) {
     $this->encryptService = $encrypt_service;
+    $this->queryFactory = $query_factory;
+    $this->entityManager = $entity_manager;
   }
 
   /**
@@ -73,8 +99,8 @@ class FieldEncryptProcessEntities {
    *
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity
    */
-  public function encrypt_fields(\Drupal\Core\Entity\ContentEntityInterface $entity) {
-    $this->process_fields($entity, 'encrypt');
+  public function encrypt_entity(\Drupal\Core\Entity\ContentEntityInterface $entity) {
+    $this->process_entity($entity, 'encrypt');
   }
 
   /**
@@ -82,8 +108,8 @@ class FieldEncryptProcessEntities {
    *
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity
    */
-  public function decrypt_fields(\Drupal\Core\Entity\ContentEntityInterface $entity) {
-    $this->process_fields($entity, 'decrypt');
+  public function decrypt_entity(\Drupal\Core\Entity\ContentEntityInterface $entity) {
+    $this->process_entity($entity, 'decrypt');
   }
 
   /**
@@ -94,6 +120,11 @@ class FieldEncryptProcessEntities {
    * @return string
    */
   protected function process_value($value = '', $op = 'encrypt') {
+    // Do not modify empty strings.
+    if ($value === ''){
+      return '';
+    }
+
     if ($op === 'encrypt') {
       return $this->encryptService->encrypt($value);
     }
@@ -106,6 +137,77 @@ class FieldEncryptProcessEntities {
   }
 
   /**
+   * Process a field.
+   *
+   * @param \Drupal\Core\Field\FieldItemListInterface $field
+   * @param string $op
+   * @param boolean $force if set, we don't check if encryption is enabled, we process the field anyway. This is used during batch processes.
+   */
+  protected function process_field(\Drupal\Core\Field\FieldItemListInterface $field, $op = 'encrypt', $force = FALSE) {
+    if (!is_callable([$field, 'getFieldDefinition'])){return;}
+
+    /**
+     * @var $definition \Drupal\Core\Field\BaseFieldDefinition
+     */
+    $definition = $field->getFieldDefinition();
+
+    if (!is_callable([$definition, 'get'])){
+      return;
+    }
+
+    /**
+     * Filter (blacklist) field types that don't work with encryption.
+     */
+    if (in_array($definition->get('field_type'), $this->blacklist_fields)) {
+      return;
+    }
+
+    /**
+     * @var $storage \Drupal\Core\Field\FieldConfigStorageBase
+     */
+    $storage = $definition->get('fieldStorage');
+    if (is_null($storage)) {
+      return;
+    }
+
+    /**
+     * If we are using the force flag, we always proceed.
+     * The force flag is used when we are updating stored fields.
+     */
+    if (!$force) {
+      /**
+       * Check if we are updating the field, in that case, skip it now (during
+       * the initial entity load.
+       */
+      if ($this->updatingStoredField === $definition->get('field_name')) {
+        return;
+      }
+
+      // Check if the field is encrypted.
+      $encrypted = $storage->getThirdPartySetting('field_encrypt', 'encrypt', FALSE);
+      if (!$encrypted) {
+        return;
+      }
+    }
+
+    /**
+     * @var $field \Drupal\Core\Field\FieldItemList
+     */
+    $field_value = $field->getValue();
+    foreach($field_value as &$value) {
+      // Process each of the sub fields that exits.
+      foreach($this->field_value_fields as $field_name) {
+        if(isset($value[$field_name])){
+          $value[$field_name] = $this->process_value($value[$field_name], $op);
+        }
+      }
+    }
+    // Set the new value.
+    // We don't need to update the entity because the field setValue does that already.
+    $field->setValue($field_value);
+  }
+
+  /**
    * Process an entity to either encrypt or decrypt its fields.
    *
    * Both processes are very similar, so we bundle the field processing part.
@@ -113,58 +215,86 @@ class FieldEncryptProcessEntities {
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity
    * @param string $op
    */
-  protected function process_fields(\Drupal\Core\Entity\ContentEntityInterface $entity, $op = 'encrypt') {
-    // Make sure we can get field definitions.
-    if (!is_callable([$entity, 'getFieldDefinitions'])){return;}
-    if (!is_callable([$entity, 'getFields'])){return;}
-    //$entity->getFieldDefinitions();
-    $entity->getFields();
+  protected function process_entity(\Drupal\Core\Entity\ContentEntityInterface $entity, $op = 'encrypt') {
+    // Make sure we can get fields.
+    if (!is_callable([$entity, 'getFields'])){
+      return;
+    }
+
+    foreach ($entity->getFields() as $field){
+      $this->process_field($field, $op);
+    }
+  }
+
+  /**
+   * Encrypt stored fields.
+   *
+   * This is performed when field storage settings are updated.
+   *
+   * @param $entity_type
+   * @param $field_name
+   */
+  public function encrypt_stored_field($entity_type, $field_name) {
+    $this->update_stored_field($entity_type, $field_name, 'encrypt');
+  }
+
+  /**
+   * Decrypt stored fields.
+   *
+   * This is performed when field storage settings are updated.
+   *
+   * @param $entity_type
+   * @param $field_name
+   */
+  public function decrypt_stored_field($entity_type, $field_name) {
+    $this->update_stored_field($entity_type, $field_name, 'decrypt');
+  }
+
+  /**
+   * Update a field. This is used to process fields when the storage
+   * configuration changes.
+   *
+   * @param $entity_type
+   * @param $field_name
+   * @param string $op (encrypt / decrypt)
+   */
+  protected function update_stored_field($entity_type, $field_name, $op = 'encrypt') {
+    /**
+     * Before we load entities, we have to disable the encryption setting.
+     * Otherwise, the act of loading the entity triggers an improper decryption
+     * Which messes up the batch encryption.
+     */
+    $this->updatingStoredField = $field_name;
 
     /**
-     * @var $definition \Drupal\Core\Field\FieldItemBase
+     * @var $query \Drupal\Core\Entity\Query\QueryInterface
      */
-    foreach($entity->getFieldDefinitions() as $name => $definition) {
-      if (!is_callable([$definition, 'get'])){
-        continue;
-      }
+    $query = $this->queryFactory->get($entity_type);
 
+    // The field is not null.
+    $query->condition($field_name, NULL, '<>');
+    $entity_ids = $query->execute();
+
+    // Load entities.
+    /**
+     * @var $entity_storage \Drupal\Core\Entity\ContentEntityStorageBase
+     */
+    $entity_storage = $this->entityManager->getStorage($entity_type);
+
+    foreach($entity_ids as $eid) {
       /**
-       * Filter (blacklist) field types that don't work with encryption.
+       * @var $entity \Drupal\Core\Entity\Entity
        */
-      if (in_array($definition->get('field_type'),$this->blacklist_fields)) {
-        continue;
-      }
-
-      /**
-       * @var $storage \Drupal\Core\Field\FieldConfigStorageBase
-       */
-      $storage = $definition->get('fieldStorage');
-      if (is_null($storage)) {
-        continue;
-      }
-
-      // Check if the field is encrypted.
-      $encrypted = $storage->getThirdPartySetting('field_encrypt', 'encrypt', FALSE);
-      if (!$encrypted) {
-        continue;
-      }
+      $entity = $entity_storage->load($eid);
 
       /**
        * @var $field \Drupal\Core\Field\FieldItemList
        */
-      $field = $entity->get($name);
-      $field_value = $field->getValue();
-      foreach($field_value as &$value) {
-        // Process each of the sub fields that exits.
-        foreach($this->field_value_fields as $field_name) {
-          if(isset($value[$field_name])){
-            $value[$field_name] = $this->process_value($value[$field_name], $op);
-          }
-        }
-      }
-      // Set the new value.
-      // We don't need to update the entity because the field setValue does that already.
-      $field->setValue($field_value);
+      $field = $entity->get($field_name);
+      $this->process_field($field, $op, TRUE);
+
+      // Save the entity.
+      $entity->save();
     }
   }
 


### PR DESCRIPTION
This is a refactor to use the service pattern instead of a module functions.

Currently, single and multi-value fields are supported for text, text_with_summary, comment, email, and link field types.

Fields are updated when the settings are changed.

There are a number of fields I don't think we can support because the encypted values do not fit into the normal database storage.
