### PR TITLE
Travis CI with Drupal TI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,12 +93,10 @@ install:
   - drupal-ti install
 
 before_script:
-  # Manually enable encrypt module
-  - set -e $DRUPAL_TI_DEBUG
-  - drupal_ti_ensure_drupal
-  - cd "$DRUPAL_TI_DRUPAL_DIR"
-  - git clone https://github.com/d8-contrib-modules/encrypt.git modules/encrypt
-  # Run standard drupal-ti script
+  # We run our script to add module dependencies
+  # This uses git clone over HTTPS because the modules don't currently
+  # exist on drupal.org.
+  - drupal-ti --include drupal_ti/before/before_script.sh
   - drupal-ti before_script
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ before_script:
   # Manually enable encrypt module
   #- drupal_ti_ensure_drupal
   - cd "$DRUPAL_TI_DRUPAL_DIR"
-  - git clone git@github.com:d8-contrib-modules/encrypt.git modules/encrypt
+  - git clone https://github.com/d8-contrib-modules/encrypt.git modules/encrypt
   # Run standard drupal-ti script
   - drupal-ti before_script
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,8 @@ install:
 
 before_script:
   # Manually enable encrypt module
-  #- drupal_ti_ensure_drupal
+  - set -e $DRUPAL_TI_DEBUG
+  - drupal_ti_ensure_drupal
   - cd "$DRUPAL_TI_DRUPAL_DIR"
   - git clone https://github.com/d8-contrib-modules/encrypt.git modules/encrypt
   # Run standard drupal-ti script

--- a/tests/drupal_ti/before/before_script.sh
+++ b/tests/drupal_ti/before/before_script.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo "running drupal_ti/before/before_script.sh"
+
+set -e $DRUPAL_TI_DEBUG
+
+# Ensure the right Drupal version is installed.
+# Note: This function is re-entrant.
+drupal_ti_ensure_drupal
+
+echo "installed drupal"
+
+# Change to the Drupal Directory
+cd "$DRUPAL_TI_DRUPAL_DIR"
+
+# Manually clone the dependencies
+git clone https://github.com/d8-contrib-modules/encrypt.git modules/encrypt
+git clone https://github.com/d8-contrib-modules/key.git modules/key


### PR DESCRIPTION
This uses a custom Drupal TI script to manually add the dependent modules `key` and `encrypt` to the repo.
