### PR TITLE
WIP - first attempt to store encrypted field values in a dedicated Co…

### DIFF
--- a/field_encrypt.module
+++ b/field_encrypt.module
@@ -6,6 +6,7 @@
 
 use Drupal\Core\Form\FormStateInterface;
 
+
 /**
  * Implements hook_form_alter().
  *
@@ -174,7 +175,9 @@ function field_encrypt_entity_encrypt(Drupal\Core\Entity\EntityInterface $entity
   if ($entity->encrypting != TRUE) {
     $entity->encrypting = TRUE;
     // Our encryption save action should never trigger a new revision.
-    $entity->setNewRevision(FALSE);
+    if ($entity->getEntityType()->hasKey('revision')) {
+      $entity->setNewRevision(FALSE);
+    }
     $entity->save();
   }
 }

--- a/field_encrypt.module
+++ b/field_encrypt.module
@@ -1,35 +1,27 @@
 <?php
 /**
- * Contains module hooks for field_encrypt
+ * @file
+ * Contains module hooks for field_encrypt.
  */
 
-use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\field_encrypt\Entity\EncryptedFieldValueInterface;
 
 /**
- * Implements hook_form_alter.
+ * Implements hook_form_alter().
  *
  * Adds settings to the field storage configuration forms to allow setting the
  * encryption state.
- *
- * @param array $form
- *   The complete form array.
- * @param \Drupal\Core\Form\FormStateInterface $form_state
- *   The current state of the form.
- * @param string $form_id
- *   The form ID.
  */
 function field_encrypt_form_alter(&$form, FormStateInterface $form_state, $form_id) {
 
   // If this is the add or edit form for field_storage, we call our function.
   if (in_array($form_id, ['field_storage_add_form', 'field_storage_config_edit_form'])) {
 
-    // Check permissions
+    // Check permissions.
     $user = \Drupal::currentUser();
 
     if ($user->hasPermission('administer field encryption')) {
-       /* @var $field \Drupal\field\Entity\FieldStorageConfig */
+      /* @var $field \Drupal\field\Entity\FieldStorageConfig */
       $field = $form_state->getFormObject()->getEntity();
       $field_type = $field->getType();
       $default_properties = \Drupal::config('field_encrypt.settings')->get('default_properties');
@@ -69,8 +61,8 @@ function field_encrypt_form_alter(&$form, FormStateInterface $form_state, $form_
         '#states' => [
           'visible' => [
             ':input[name="field_encrypt[encrypt]"]' => array('checked' => TRUE),
-          ]
-        ]
+          ],
+        ],
       ];
 
       $encryption_profile_manager = \Drupal::service('encrypt.encryption_profile.manager');
@@ -83,8 +75,8 @@ function field_encrypt_form_alter(&$form, FormStateInterface $form_state, $form_
         '#states' => [
           'visible' => [
             ':input[name="field_encrypt[encrypt]"]' => array('checked' => TRUE),
-          ]
-        ]
+          ],
+        ],
       );
 
       // We add a function to process the form when it is saved.
@@ -96,7 +88,6 @@ function field_encrypt_form_alter(&$form, FormStateInterface $form_state, $form_
 /**
  * Update the field storage configuration to set the encryption state.
  *
- *
  * @param string $entity_type
  *   The entity type.
  * @param \Drupal\field\Entity\FieldStorageConfig $fieldStorageConfig
@@ -105,7 +96,6 @@ function field_encrypt_form_alter(&$form, FormStateInterface $form_state, $form_
  *   The complete form array.
  * @param \Drupal\Core\Form\FormStateInterface $form_state
  *   The current state of the form.
- *
  */
 function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\Entity\FieldStorageConfig $fieldStorageConfig, &$form, \Drupal\Core\Form\FormStateInterface $form_state) {
   $field_encryption_settings = $form_state->getValue('field_encrypt');
@@ -134,13 +124,13 @@ function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\E
      * @var $field_encrypt_process_entities \Drupal\field_encrypt\FieldEncryptProcessEntities
      */
     // @TODO: refactor logic for re-encrypting existing fields - currently broken, so commented out.
-//    $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
-//    if ($form_encryption === 1) {
-//      $field_encrypt_process_entities->encryptStoredField($field_entity_type, $field_name);
-//    }
-//    elseif ($form_encryption === 0) {
-//      $field_encrypt_process_entities->decryptStoredField($field_entity_type, $field_name);
-//    }
+    //    $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
+    //    if ($form_encryption === 1) {
+    //      $field_encrypt_process_entities->encryptStoredField($field_entity_type, $field_name);
+    //    }
+    //    elseif ($form_encryption === 0) {
+    //      $field_encrypt_process_entities->decryptStoredField($field_entity_type, $field_name);
+    //    }
   }
 }
 
@@ -148,17 +138,14 @@ function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\E
  * Implements hook_entity_insert().
  *
  * Encrypts the entity after being saved for the first time.
- *
- * @param \Drupal\Core\Entity\EntityInterface $entity
- *   The inserted entity.
  */
 function field_encrypt_entity_insert(Drupal\Core\Entity\EntityInterface $entity) {
-  if (($entity instanceof Drupal\field_encrypt\Entity\EncryptedFieldValueInterface)) {return;}
+  if (($entity instanceof Drupal\field_encrypt\Entity\EncryptedFieldValueInterface)) {
+    return;
+  }
   // Save the entity again, but now encrypted.
   // @TODO: check if there's not a cleaner way to do this.
-  // @TODO: this actually doesn't work - fix it.
   $saved_entity = entity_load($entity->getEntityTypeId(), $entity->id());
-  //$saved_entity = field_encrypt_save_entity($entity);
   if ($saved_entity) {
     $saved_entity->save();
   }
@@ -168,50 +155,47 @@ function field_encrypt_entity_insert(Drupal\Core\Entity\EntityInterface $entity)
  * Implements hook_entity_presave().
  *
  * Encrypt entity fields before they are saved.
- *
- * @param \Drupal\Core\Entity\EntityInterface $entity
- *   The entity to be saved.
  */
 function field_encrypt_entity_presave(\Drupal\Core\Entity\EntityInterface $entity) {
-  if (($entity instanceof Drupal\field_encrypt\Entity\EncryptedFieldValueInterface)) {return;}
+  if (($entity instanceof Drupal\field_encrypt\Entity\EncryptedFieldValueInterface) || !($entity instanceof Drupal\Core\Entity\ContentEntityInterface)) {
+    return;
+  }
+
   if (!$entity->isNew()) {
-    field_encrypt_save_entity($entity);
+    /* @var $field_encrypt_process_entities \Drupal\field_encrypt\FieldEncryptProcessEntities */
+    $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
+    $field_encrypt_process_entities->encryptEntity($entity);
   }
 }
 
 /**
- * Encrypt fields on a given entity.
+ * Implement hook_entity_storage_load().
  *
- * @param \Drupal\Core\Entity\EntityInterface $entity
- *   The entity to process.
- *
- * @return \Drupal\Core\Entity\EntityInterface
- *   The processed entity.
+ * Decrypt entity fields when loading entities.
  */
-function field_encrypt_save_entity(\Drupal\Core\Entity\EntityInterface $entity) {
-  if (!($entity instanceof Drupal\Core\Entity\ContentEntityInterface)) {return;}
-  /**
-   * @var $field_encrypt_process_entities \Drupal\field_encrypt\FieldEncryptProcessEntities
-   */
-  $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
-  $entity = $field_encrypt_process_entities->encryptEntity($entity);
-  return $entity;
-}
-
-/**
- * Decrypt fields before they are rendered.
- *
- * @param $entities
- * @param $entity_type
- */
-function field_encrypt_entity_load($entities, $entity_type) {
+function field_encrypt_entity_storage_load($entities, $entity_type) {
   /**
    * @var $field_encrypt_process_entities \Drupal\field_encrypt\FieldEncryptProcessEntities
    */
   $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
 
-  foreach($entities as &$entity) {
-    if (!($entity instanceof Drupal\Core\Entity\ContentEntityInterface)) {continue;}
+  foreach ($entities as &$entity) {
+    if (!($entity instanceof Drupal\Core\Entity\ContentEntityInterface)) {
+      continue;
+    }
     $field_encrypt_process_entities->decryptEntity($entity);
   }
+}
+
+/**
+ * Implements hook_entity_delete().
+ *
+ * Remove EncryptedFieldValues associated with this entity.
+ */
+function field_encrypt_entity_delete(Drupal\Core\Entity\EntityInterface $entity) {
+  if (!($entity instanceof Drupal\Core\Entity\ContentEntityInterface)) {
+    return;
+  }
+  $encrypted_field_value_manager = \Drupal::service('field_encrypt.encrypted_field_value_manager');
+  $encrypted_field_value_manager->deleteEncryptedFieldValues($entity);
 }

--- a/field_encrypt.module
+++ b/field_encrypt.module
@@ -4,8 +4,8 @@
  * Contains module hooks for field_encrypt.
  */
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
-
 
 /**
  * Implements hook_form_alter().
@@ -91,39 +91,38 @@ function field_encrypt_form_alter(&$form, FormStateInterface $form_state, $form_
  *
  * @param string $entity_type
  *   The entity type.
- * @param \Drupal\field\Entity\FieldStorageConfig $fieldStorageConfig
+ * @param \Drupal\field\Entity\FieldStorageConfig $field_storage_config
  *   The field storage config entity.
  * @param array $form
  *   The complete form array.
  * @param \Drupal\Core\Form\FormStateInterface $form_state
  *   The current state of the form.
  */
-function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\Entity\FieldStorageConfig $fieldStorageConfig, &$form, \Drupal\Core\Form\FormStateInterface $form_state) {
+function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\Entity\FieldStorageConfig $field_storage_config, &$form, \Drupal\Core\Form\FormStateInterface $form_state) {
   $field_encryption_settings = $form_state->getValue('field_encrypt');
   $form_encryption = $field_encryption_settings['encrypt'];
-  $original_encryption = $fieldStorageConfig->getThirdPartySettings('field_encrypt');
+  $original_encryption = $field_storage_config->getThirdPartySettings('field_encrypt');
 
   // If the form has the value, we set it.
   if ($form_encryption === 1) {
     foreach ($field_encryption_settings as $settings_key => $settings_value) {
-      $fieldStorageConfig->setThirdPartySetting('field_encrypt', $settings_key, $settings_value);
+      $field_storage_config->setThirdPartySetting('field_encrypt', $settings_key, $settings_value);
     }
   }
   else {
     // If there is no value, remove third party settings.
-    $fieldStorageConfig->unsetThirdPartySetting('field_encrypt', 'encrypt');
-    $fieldStorageConfig->unsetThirdPartySetting('field_encrypt', 'properties');
-    $fieldStorageConfig->unsetThirdPartySetting('field_encrypt', 'encryption_profile');
+    $field_storage_config->unsetThirdPartySetting('field_encrypt', 'encrypt');
+    $field_storage_config->unsetThirdPartySetting('field_encrypt', 'properties');
+    $field_storage_config->unsetThirdPartySetting('field_encrypt', 'encryption_profile');
   }
 
-  if ($original_encryption !== $fieldStorageConfig->getThirdPartySettings('field_encrypt')) {
-    // We need to process the field to either encrypt or decrypt the stored fields if the setting was changed.
-    $field_name = $fieldStorageConfig->get('field_name');
-    $field_entity_type = $fieldStorageConfig->get('entity_type');
+  if ($original_encryption !== $field_storage_config->getThirdPartySettings('field_encrypt')) {
+    // We need to process the field to either encrypt or decrypt the stored
+    // fields if the setting was changed.
+    $field_name = $field_storage_config->get('field_name');
+    $field_entity_type = $field_storage_config->get('entity_type');
 
-    /**
-     * @var $field_encrypt_process_entities \Drupal\field_encrypt\FieldEncryptProcessEntities
-     */
+    /* @var $field_encrypt_process_entities \Drupal\field_encrypt\FieldEncryptProcessEntities */
     // @TODO: refactor logic for re-encrypting existing fields - currently broken, so commented out.
     //    $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
     //    if ($form_encryption === 1) {
@@ -140,7 +139,7 @@ function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\E
  *
  * Encrypts the entity after being saved for the first time.
  */
-function field_encrypt_entity_insert(Drupal\Core\Entity\EntityInterface $entity) {
+function field_encrypt_entity_insert(EntityInterface $entity) {
   // Save the entity again, but now encrypted.
   // @TODO: check if there's not a cleaner way to do this.
   $saved_entity = entity_load($entity->getEntityTypeId(), $entity->id());
@@ -152,7 +151,7 @@ function field_encrypt_entity_insert(Drupal\Core\Entity\EntityInterface $entity)
  *
  * Encrypts the entity after being updated.
  */
-function field_encrypt_entity_update(Drupal\Core\Entity\EntityInterface $entity) {
+function field_encrypt_entity_update(EntityInterface $entity) {
   field_encrypt_entity_encrypt($entity);
 }
 
@@ -160,25 +159,25 @@ function field_encrypt_entity_update(Drupal\Core\Entity\EntityInterface $entity)
  * Encrypt the saved entity.
  *
  * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The entity to encrypt fields on, if appropriate.
  */
-function field_encrypt_entity_encrypt(Drupal\Core\Entity\EntityInterface $entity) {
-  if (($entity instanceof Drupal\field_encrypt\Entity\EncryptedFieldValueInterface) || !($entity instanceof Drupal\Core\Entity\ContentEntityInterface)) {
-    return;
-  }
-  // Check if this entity has fields that should be encrypted.
-  $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
-  if (!$field_encrypt_process_entities->checkEntity($entity)) {
-    return;
-  }
-
-  // Set a flag to only perform the encryption once.
-  if ($entity->encrypting != TRUE) {
-    $entity->encrypting = TRUE;
-    // Our encryption save action should never trigger a new revision.
-    if ($entity->getEntityType()->hasKey('revision')) {
-      $entity->setNewRevision(FALSE);
+function field_encrypt_entity_encrypt(EntityInterface $entity) {
+  if (field_encrypt_allow_encryption($entity)) {
+    // Check if this entity has fields that should be encrypted.
+    $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
+    if (!$field_encrypt_process_entities->entityHasEncryptedFields($entity)) {
+      return;
     }
-    $entity->save();
+
+    // Set a flag to only perform the encryption once.
+    if ($entity->doFieldEncryption != TRUE) {
+      $entity->doFieldEncryption = TRUE;
+      // Our encryption save action should never trigger a new revision.
+      if ($entity->getEntityType()->hasKey('revision')) {
+        $entity->setNewRevision(FALSE);
+      }
+      $entity->save();
+    }
   }
 }
 
@@ -187,39 +186,31 @@ function field_encrypt_entity_encrypt(Drupal\Core\Entity\EntityInterface $entity
  *
  * Encrypt entity fields before they are saved.
  */
-function field_encrypt_entity_presave(\Drupal\Core\Entity\EntityInterface $entity) {
-  if (($entity instanceof Drupal\field_encrypt\Entity\EncryptedFieldValueInterface) || !($entity instanceof Drupal\Core\Entity\ContentEntityInterface)) {
-    return;
-  }
-
-  // Only encrypt when the correct flag is set.
-  if ($entity->encrypting == TRUE) {
-    /* @var $field_encrypt_process_entities \Drupal\field_encrypt\FieldEncryptProcessEntities */
-    $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
-    $field_encrypt_process_entities->encryptEntity($entity);
+function field_encrypt_entity_presave(EntityInterface $entity) {
+  if (field_encrypt_allow_encryption($entity)) {
+    // Only encrypt when the correct flag is set.
+    if ($entity->doFieldEncryption == TRUE) {
+      /* @var $field_encrypt_process_entities \Drupal\field_encrypt\FieldEncryptProcessEntities */
+      $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
+      $field_encrypt_process_entities->encryptEntity($entity);
+    }
   }
 }
 
 /**
- * Implement hook_entity_storage_load().
+ * Implements hook_entity_storage_load().
  *
  * Decrypt entity fields when loading entities.
  */
 function field_encrypt_entity_storage_load($entities, $entity_type) {
-  /**
-   * @var $field_encrypt_process_entities \Drupal\field_encrypt\FieldEncryptProcessEntities
-   */
+  /* @var $field_encrypt_process_entities \Drupal\field_encrypt\FieldEncryptProcessEntities */
   $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
 
   foreach ($entities as &$entity) {
-    if (!($entity instanceof Drupal\Core\Entity\ContentEntityInterface)) {
-      continue;
-    }
-    if (!$field_encrypt_process_entities->checkEntity($entity)) {
-      continue;
-    }
-    else {
-      $field_encrypt_process_entities->decryptEntity($entity);
+    if (field_encrypt_allow_encryption($entity)) {
+      if ($field_encrypt_process_entities->entityHasEncryptedFields($entity)) {
+        $field_encrypt_process_entities->decryptEntity($entity);
+      }
     }
   }
 }
@@ -229,10 +220,33 @@ function field_encrypt_entity_storage_load($entities, $entity_type) {
  *
  * Remove EncryptedFieldValues associated with this entity.
  */
-function field_encrypt_entity_delete(Drupal\Core\Entity\EntityInterface $entity) {
-  if (!($entity instanceof Drupal\Core\Entity\ContentEntityInterface)) {
-    return;
+function field_encrypt_entity_delete(EntityInterface $entity) {
+  if (field_encrypt_allow_encryption($entity)) {
+    $encrypted_field_value_manager = \Drupal::service('field_encrypt.encrypted_field_value_manager');
+    $encrypted_field_value_manager->deleteEncryptedFieldValues($entity);
   }
-  $encrypted_field_value_manager = \Drupal::service('field_encrypt.encrypted_field_value_manager');
-  $encrypted_field_value_manager->deleteEncryptedFieldValues($entity);
+}
+
+/**
+ * Verify if the given entity allows to be encrypted.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The entity to check.
+ *
+ * @return bool
+ *   Boolean indicating hether the entity could be encrypted.
+ */
+function field_encrypt_allow_encryption(EntityInterface $entity) {
+  $allowed = TRUE;
+
+  // We don't want to encrypt the encrypted data storage.
+  if ($entity instanceof Drupal\field_encrypt\Entity\EncryptedFieldValueInterface) {
+    $allowed = FALSE;
+  }
+
+  // We only want to encrypt content entities.
+  if (!$entity instanceof Drupal\Core\Entity\ContentEntityInterface) {
+    $allowed = FALSE;
+  }
+  return $allowed;
 }

--- a/field_encrypt.module
+++ b/field_encrypt.module
@@ -3,7 +3,9 @@
  * Contains module hooks for field_encrypt
  */
 
+use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\field_encrypt\Entity\EncryptedFieldValueInterface;
 
 /**
  * Implements hook_form_alter.
@@ -131,28 +133,69 @@ function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\E
     /**
      * @var $field_encrypt_process_entities \Drupal\field_encrypt\FieldEncryptProcessEntities
      */
-    $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
-    if ($form_encryption === 1) {
-      $field_encrypt_process_entities->encryptStoredField($field_entity_type, $field_name);
-    }
-    elseif ($form_encryption === 0) {
-      $field_encrypt_process_entities->decryptStoredField($field_entity_type, $field_name);
-    }
+    // @TODO: refactor logic for re-encrypting existing fields - currently broken, so commented out.
+//    $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
+//    if ($form_encryption === 1) {
+//      $field_encrypt_process_entities->encryptStoredField($field_entity_type, $field_name);
+//    }
+//    elseif ($form_encryption === 0) {
+//      $field_encrypt_process_entities->decryptStoredField($field_entity_type, $field_name);
+//    }
   }
 }
 
 /**
- * Encrypt fields before they are saved.
+ * Implements hook_entity_insert().
+ *
+ * Encrypts the entity after being saved for the first time.
  *
  * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The inserted entity.
+ */
+function field_encrypt_entity_insert(Drupal\Core\Entity\EntityInterface $entity) {
+  if (($entity instanceof Drupal\field_encrypt\Entity\EncryptedFieldValueInterface)) {return;}
+  // Save the entity again, but now encrypted.
+  // @TODO: check if there's not a cleaner way to do this.
+  // @TODO: this actually doesn't work - fix it.
+  $saved_entity = entity_load($entity->getEntityTypeId(), $entity->id());
+  //$saved_entity = field_encrypt_save_entity($entity);
+  if ($saved_entity) {
+    $saved_entity->save();
+  }
+}
+
+/**
+ * Implements hook_entity_presave().
+ *
+ * Encrypt entity fields before they are saved.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The entity to be saved.
  */
 function field_encrypt_entity_presave(\Drupal\Core\Entity\EntityInterface $entity) {
+  if (($entity instanceof Drupal\field_encrypt\Entity\EncryptedFieldValueInterface)) {return;}
+  if (!$entity->isNew()) {
+    field_encrypt_save_entity($entity);
+  }
+}
+
+/**
+ * Encrypt fields on a given entity.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The entity to process.
+ *
+ * @return \Drupal\Core\Entity\EntityInterface
+ *   The processed entity.
+ */
+function field_encrypt_save_entity(\Drupal\Core\Entity\EntityInterface $entity) {
   if (!($entity instanceof Drupal\Core\Entity\ContentEntityInterface)) {return;}
   /**
    * @var $field_encrypt_process_entities \Drupal\field_encrypt\FieldEncryptProcessEntities
    */
   $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
-  $field_encrypt_process_entities->encryptEntity($entity);
+  $entity = $field_encrypt_process_entities->encryptEntity($entity);
+  return $entity;
 }
 
 /**

--- a/field_encrypt.module
+++ b/field_encrypt.module
@@ -140,14 +140,42 @@ function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\E
  * Encrypts the entity after being saved for the first time.
  */
 function field_encrypt_entity_insert(Drupal\Core\Entity\EntityInterface $entity) {
-  if (($entity instanceof Drupal\field_encrypt\Entity\EncryptedFieldValueInterface)) {
-    return;
-  }
   // Save the entity again, but now encrypted.
   // @TODO: check if there's not a cleaner way to do this.
   $saved_entity = entity_load($entity->getEntityTypeId(), $entity->id());
-  if ($saved_entity) {
-    $saved_entity->save();
+  field_encrypt_entity_encrypt($saved_entity);
+}
+
+/**
+ * Implements hook_entity_update().
+ *
+ * Encrypts the entity after being updated.
+ */
+function field_encrypt_entity_update(Drupal\Core\Entity\EntityInterface $entity) {
+  field_encrypt_entity_encrypt($entity);
+}
+
+/**
+ * Encrypt the saved entity.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ */
+function field_encrypt_entity_encrypt(Drupal\Core\Entity\EntityInterface $entity) {
+  if (($entity instanceof Drupal\field_encrypt\Entity\EncryptedFieldValueInterface) || !($entity instanceof Drupal\Core\Entity\ContentEntityInterface)) {
+    return;
+  }
+  // Check if this entity has fields that should be encrypted.
+  $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
+  if (!$field_encrypt_process_entities->checkEntity($entity)) {
+    return;
+  }
+
+  // Set a flag to only perform the encryption once.
+  if ($entity->encrypting != TRUE) {
+    $entity->encrypting = TRUE;
+    // Our encryption save action should never trigger a new revision.
+    $entity->setNewRevision(FALSE);
+    $entity->save();
   }
 }
 
@@ -161,7 +189,8 @@ function field_encrypt_entity_presave(\Drupal\Core\Entity\EntityInterface $entit
     return;
   }
 
-  if (!$entity->isNew()) {
+  // Only encrypt when the correct flag is set.
+  if ($entity->encrypting == TRUE) {
     /* @var $field_encrypt_process_entities \Drupal\field_encrypt\FieldEncryptProcessEntities */
     $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
     $field_encrypt_process_entities->encryptEntity($entity);
@@ -183,7 +212,12 @@ function field_encrypt_entity_storage_load($entities, $entity_type) {
     if (!($entity instanceof Drupal\Core\Entity\ContentEntityInterface)) {
       continue;
     }
-    $field_encrypt_process_entities->decryptEntity($entity);
+    if (!$field_encrypt_process_entities->checkEntity($entity)) {
+      continue;
+    }
+    else {
+      $field_encrypt_process_entities->decryptEntity($entity);
+    }
   }
 }
 

--- a/field_encrypt.services.yml
+++ b/field_encrypt.services.yml
@@ -1,4 +1,8 @@
 services:
   field_encrypt.process_entities:
     class: Drupal\field_encrypt\FieldEncryptProcessEntities
-    arguments: ['@entity.query', '@entity.manager', '@encryption', '@encrypt.encryption_profile.manager']
+    arguments: ['@entity.query', '@entity.manager', '@encryption', '@encrypt.encryption_profile.manager', '@field_encrypt.encrypted_field_value_manager']
+
+  field_encrypt.encrypted_field_value_manager:
+    class: Drupal\field_encrypt\EncryptedFieldValueManager
+    arguments: ['@entity_type.manager', '@entity.query']

--- a/src/EncryptedFieldValueManager.php
+++ b/src/EncryptedFieldValueManager.php
@@ -76,6 +76,8 @@ class EncryptedFieldValueManager implements EncryptedFieldValueManagerInterface 
   }
 
   /**
+   * Loads an existing EncryptedFieldValue entity.
+   *
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity
    *   The entity to check.
    * @param string $field_name
@@ -99,6 +101,19 @@ class EncryptedFieldValueManager implements EncryptedFieldValueManagerInterface 
       return EncryptedFieldValue::load($id);
     }
     return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function deleteEncryptedFieldValues(ContentEntityInterface $entity) {
+    $field_values = $this->entityManager->getStorage('encrypted_field_value')->loadByProperties([
+      'entity_type' => $entity->getEntityTypeId(),
+      'entity_id' => $entity->id(),
+    ]);
+    if ($field_values) {
+      $this->entityManager->getStorage('encrypted_field_value')->delete($field_values);
+    }
   }
 
 }

--- a/src/EncryptedFieldValueManager.php
+++ b/src/EncryptedFieldValueManager.php
@@ -55,7 +55,7 @@ class EncryptedFieldValueManager implements EncryptedFieldValueManagerInterface 
       $encrypted_field_value = EncryptedFieldValue::create([
         'entity_type' => $entity->getEntityTypeId(),
         'entity_id' => $entity->id(),
-        'entity_revision_id' => $entity->getRevisionId(),
+        'entity_revision_id' => $this->getEntityRevisionId($entity),
         'field_name' => $field_name,
         'field_property' => $property,
         'encrypted_value' => $encrypted_value,
@@ -90,10 +90,11 @@ class EncryptedFieldValueManager implements EncryptedFieldValueManagerInterface 
    *   The existing EncryptedFieldValue entity.
    */
   protected function getExistingEntity(ContentEntityInterface $entity, $field_name, $property) {
+    $revision_id = $entity->getRevisionId();
     $query = $this->entityQuery->get('encrypted_field_value')
       ->condition('entity_type', $entity->getEntityTypeId())
       ->condition('entity_id', $entity->id())
-      ->condition('entity_revision_id', $entity->getRevisionId())
+      ->condition('entity_revision_id', $this->getEntityRevisionId($entity))
       ->condition('field_name', $field_name)
       ->condition('field_property', $property);
     $values = $query->execute();
@@ -116,6 +117,25 @@ class EncryptedFieldValueManager implements EncryptedFieldValueManagerInterface 
     if ($field_values) {
       $this->entityManager->getStorage('encrypted_field_value')->delete($field_values);
     }
+  }
+
+  /**
+   * Get the revision ID to store for a given entity.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity to check.
+   *
+   * @return int
+   *   The revision ID.
+   */
+  protected function getEntityRevisionId($entity) {
+    if ($entity->getEntityType()->hasKey('revision')) {
+      $revision_id = $entity->getRevisionId();
+    }
+    else {
+      $revision_id = $entity->id();
+    }
+    return $revision_id;
   }
 
 }

--- a/src/EncryptedFieldValueManager.php
+++ b/src/EncryptedFieldValueManager.php
@@ -55,6 +55,7 @@ class EncryptedFieldValueManager implements EncryptedFieldValueManagerInterface 
       $encrypted_field_value = EncryptedFieldValue::create([
         'entity_type' => $entity->getEntityTypeId(),
         'entity_id' => $entity->id(),
+        'entity_revision_id' => $entity->getRevisionId(),
         'field_name' => $field_name,
         'field_property' => $property,
         'encrypted_value' => $encrypted_value,
@@ -92,6 +93,7 @@ class EncryptedFieldValueManager implements EncryptedFieldValueManagerInterface 
     $query = $this->entityQuery->get('encrypted_field_value')
       ->condition('entity_type', $entity->getEntityTypeId())
       ->condition('entity_id', $entity->id())
+      ->condition('entity_revision_id', $entity->getRevisionId())
       ->condition('field_name', $field_name)
       ->condition('field_property', $property);
     $values = $query->execute();

--- a/src/EncryptedFieldValueManager.php
+++ b/src/EncryptedFieldValueManager.php
@@ -134,7 +134,7 @@ class EncryptedFieldValueManager implements EncryptedFieldValueManagerInterface 
    * @return int
    *   The revision ID.
    */
-  protected function getEntityRevisionId($entity) {
+  protected function getEntityRevisionId(ContentEntityInterface $entity) {
     if ($entity->getEntityType()->hasKey('revision')) {
       $revision_id = $entity->getRevisionId();
     }

--- a/src/EncryptedFieldValueManager.php
+++ b/src/EncryptedFieldValueManager.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\field_encrypt\EncryptedFieldValueManager.
+ */
+
+namespace Drupal\field_encrypt;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Query\QueryFactory;
+use Drupal\field_encrypt\Entity\EncryptedFieldValue;
+
+/**
+ * Manager containing common functions to manage EncryptedFieldValue entities.
+ */
+class EncryptedFieldValueManager implements EncryptedFieldValueManagerInterface {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityManager;
+
+  /**
+   * The entity query service.
+   *
+   * @var \Drupal\Core\Entity\Query\QueryFactory
+   */
+  protected $entityQuery;
+
+  /**
+   * Construct the CommentManager object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_manager
+   *   The entity type manager service.
+   * @param \Drupal\Core\Entity\Query\QueryFactory $entity_query
+   *   The entity query service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_manager, QueryFactory $entity_query) {
+    $this->entityManager = $entity_manager;
+    $this->entityQuery = $entity_query;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function saveEncryptedFieldValue(ContentEntityInterface $entity, $field_name, $property, $encrypted_value) {
+    if ($encrypted_field_value = $this->getExistingEntity($entity, $field_name, $property)) {
+      $encrypted_field_value->setEncryptedValue($encrypted_value);
+    }
+    else {
+      $encrypted_field_value = EncryptedFieldValue::create([
+        'entity_type' => $entity->getEntityTypeId(),
+        'entity_id' => $entity->id(),
+        'field_name' => $field_name,
+        'field_property' => $property,
+        'encrypted_value' => $encrypted_value,
+      ]);
+    }
+    $encrypted_field_value->save();
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEncryptedFieldValue(ContentEntityInterface $entity, $field_name, $property) {
+    $field_value_entity = $this->getExistingEntity($entity, $field_name, $property);
+    if ($field_value_entity) {
+      return $field_value_entity->getEncryptedValue();
+    }
+    return FALSE;
+  }
+
+  /**
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity to check.
+   * @param string $field_name
+   *   The field name to check.
+   * @param string $property
+   *   The field property to check.
+   *
+   * @return bool|\Drupal\field_encrypt\Entity\EncryptedFieldValue
+   *   The existing EncryptedFieldValue entity.
+   */
+  protected function getExistingEntity(ContentEntityInterface $entity, $field_name, $property) {
+    $query = $this->entityQuery->get('encrypted_field_value')
+      ->condition('entity_type', $entity->getEntityTypeId())
+      ->condition('entity_id', $entity->id())
+      ->condition('field_name', $field_name)
+      ->condition('field_property', $property);
+    $values = $query->execute();
+
+    if (!empty($values)) {
+      $id = array_shift($values);
+      return EncryptedFieldValue::load($id);
+    }
+    return FALSE;
+  }
+
+}

--- a/src/EncryptedFieldValueManagerInterface.php
+++ b/src/EncryptedFieldValueManagerInterface.php
@@ -9,6 +9,11 @@ namespace Drupal\field_encrypt;
 
 use Drupal\Core\Entity\ContentEntityInterface;
 
+/**
+ * Interface EncryptedFieldValueManagerInterface.
+ *
+ * @package Drupal\field_encrypt
+ */
 interface EncryptedFieldValueManagerInterface {
 
   /**
@@ -39,5 +44,13 @@ interface EncryptedFieldValueManagerInterface {
    *   The encrypted field value.
    */
   public function getEncryptedFieldValue(ContentEntityInterface $entity, $field_name, $property);
+
+  /**
+   * Delete encrypted field values for a given entity.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity to be deleted.
+   */
+  public function deleteEncryptedFieldValues(ContentEntityInterface $entity);
 
 }

--- a/src/EncryptedFieldValueManagerInterface.php
+++ b/src/EncryptedFieldValueManagerInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\field_encrypt\EncryptedFieldValueManagerInterface.
+ */
+
+namespace Drupal\field_encrypt;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+
+interface EncryptedFieldValueManagerInterface {
+
+  /**
+   * Save an encrypted field value.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity to process.
+   * @param string $field_name
+   *   The field name to save.
+   * @param string $property
+   *   The field property to save.
+   * @param string $encrypted_value
+   *   The encrypted value to save.
+   */
+  public function saveEncryptedFieldValue(ContentEntityInterface $entity, $field_name, $property, $encrypted_value);
+
+  /**
+   * Get an encrypted field value.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity to process.
+   * @param string $field_name
+   *   The field name to retrieve.
+   * @param string $property
+   *   The field property to retrieve.
+   *
+   * @return string
+   *   The encrypted field value.
+   */
+  public function getEncryptedFieldValue(ContentEntityInterface $entity, $field_name, $property);
+
+}

--- a/src/Entity/EncryptedFieldValue.php
+++ b/src/Entity/EncryptedFieldValue.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * @file
+ * Contains \Drupal\field_encrypt\Entity\EncryptedFieldValue.
+ */
+
+namespace Drupal\field_encrypt\Entity;
+
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Entity\ContentEntityBase;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\field\Entity\FieldStorageConfig;
+
+/**
+ * Defines the EncryptedFieldValue entity.
+ *
+ * @ingroup field_encrypt
+ *
+ * @ContentEntityType(
+ *   id = "encrypted_field_value",
+ *   label = @Translation("Encrypted field value"),
+ *   base_table = "encrypted_field",
+ *   render_cache = FALSE,
+ *   admin_permission = "administer encrypted_field_value entity",
+ *   fieldable = FALSE,
+ *   entity_keys = {
+ *     "id" = "id",
+ *     "uuid" = "uuid"
+ *   },
+ * )
+ *
+ *   @TODO: check if the following settings would make sense
+ *   entity_keys -->
+ *   "revision" = "revision_id",
+ *
+ *   data_table = "encrypted_field_data",
+ *   revision_table = "encrypted_field_revision",
+ *   revision_data_table = "encrypted_field_revision_data",
+ *   translatable = TRUE,
+ *   handlers = {
+ *     "storage" = "Drupal\field_encrypt\EncryptedFieldValueStorage",
+ *     "storage_schema" = "Drupal\field_encrypt\EncryptedFieldValueStorageSchema",
+ *     "translation" = "Drupal\field_encrypt\EncryptedFieldValueTranslationHandler"
+ *   }
+ *
+ */
+class EncryptedFieldValue extends ContentEntityBase implements EncryptedFieldValueInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
+
+    // Standard field, used as unique if primary index.
+    $fields['id'] = BaseFieldDefinition::create('integer')
+      ->setLabel(t('ID'))
+      ->setDescription(t('The ID of the EncryptedFieldValue entity.'))
+      ->setReadOnly(TRUE);
+
+    // Standard field, unique outside of the scope of the current project.
+    $fields['uuid'] = BaseFieldDefinition::create('uuid')
+      ->setLabel(t('UUID'))
+      ->setDescription(t('The UUID of the EncryptedFieldValue entity.'))
+      ->setReadOnly(TRUE);
+
+    // @TODO: field language supports
+//    $fields['langcode'] = BaseFieldDefinition::create('language')
+//      ->setLabel(t('Language code'))
+//      ->setDescription(t('The language code of EncryptedFieldValue entity.'));
+
+    // @TODO: revision id
+
+    $fields['entity_type'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Entity type'))
+      ->setDescription(t('The entity type for which to store the encrypted value.'))
+      ->setSetting('is_ascii', TRUE)
+      ->setSetting('max_length', EntityTypeInterface::ID_MAX_LENGTH);
+
+    $fields['entity_id'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('Entity ID'))
+      ->setDescription(t('The ID of the entity for which to store the encrypted value.'))
+      ->setRequired(TRUE);
+
+    $fields['field_name'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Field name'))
+      ->setDescription(t('The field name for which to store the encrypted value.'))
+      ->setSetting('is_ascii', TRUE)
+      ->setSetting('max_length', FieldStorageConfig::NAME_MAX_LENGTH);
+
+    $fields['field_property'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Field property'))
+      ->setDescription(t('The field property for which to store the encrypted value.'))
+      ->setSetting('is_ascii', TRUE)
+      ->setSetting('max_length', FieldStorageConfig::NAME_MAX_LENGTH);
+
+    $fields['encrypted_value'] = BaseFieldDefinition::create('text_long')
+      ->setLabel(t('Encrypted value'))
+      ->setDescription(t('The encrypted value'));
+      //->setTranslatable(TRUE)
+
+    return $fields;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEncryptedValue() {
+    return $this->get('encrypted_value')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setEncryptedValue($value) {
+    $this->set('encrypted_value', $value);
+  }
+
+}

--- a/src/Entity/EncryptedFieldValue.php
+++ b/src/Entity/EncryptedFieldValue.php
@@ -20,23 +20,17 @@ use Drupal\field\Entity\FieldStorageConfig;
  *   id = "encrypted_field_value",
  *   label = @Translation("Encrypted field value"),
  *   base_table = "encrypted_field",
+ *   data_table = "encrypted_field_data",
  *   render_cache = FALSE,
  *   admin_permission = "administer encrypted_field_value entity",
  *   fieldable = FALSE,
+ *   translatable = TRUE,
  *   entity_keys = {
  *     "id" = "id",
  *     "uuid" = "uuid",
  *     "langcode" = "langcode"
  *   },
  * )
- *
- *   translatable = TRUE,
- *   handlers = {
- *     "storage" = "Drupal\field_encrypt\EncryptedFieldValueStorage",
- *     "storage_schema" = "Drupal\field_encrypt\EncryptedFieldValueStorageSchema",
- *     "translation" = "Drupal\field_encrypt\EncryptedFieldValueTranslationHandler"
- *   }
- *
  */
 class EncryptedFieldValue extends ContentEntityBase implements EncryptedFieldValueInterface {
 
@@ -76,9 +70,8 @@ class EncryptedFieldValue extends ContentEntityBase implements EncryptedFieldVal
 
     $fields['encrypted_value'] = BaseFieldDefinition::create('text_long')
       ->setLabel(t('Encrypted value'))
-      ->setDescription(t('The encrypted value'));
-      //->setTranslatable(TRUE)
-      //->setRevisionable(TRUE);
+      ->setDescription(t('The encrypted value'))
+      ->setTranslatable(TRUE);
 
     return $fields;
   }

--- a/src/Entity/EncryptedFieldValue.php
+++ b/src/Entity/EncryptedFieldValue.php
@@ -25,17 +25,11 @@ use Drupal\field\Entity\FieldStorageConfig;
  *   fieldable = FALSE,
  *   entity_keys = {
  *     "id" = "id",
- *     "uuid" = "uuid"
+ *     "uuid" = "uuid",
+ *     "langcode" = "langcode"
  *   },
  * )
  *
- *   @TODO: check if the following settings would make sense
- *   entity_keys -->
- *   "revision" = "revision_id",
- *
- *   data_table = "encrypted_field_data",
- *   revision_table = "encrypted_field_revision",
- *   revision_data_table = "encrypted_field_revision_data",
  *   translatable = TRUE,
  *   handlers = {
  *     "storage" = "Drupal\field_encrypt\EncryptedFieldValueStorage",
@@ -50,25 +44,7 @@ class EncryptedFieldValue extends ContentEntityBase implements EncryptedFieldVal
    * {@inheritdoc}
    */
   public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
-
-    // Standard field, used as unique if primary index.
-    $fields['id'] = BaseFieldDefinition::create('integer')
-      ->setLabel(t('ID'))
-      ->setDescription(t('The ID of the EncryptedFieldValue entity.'))
-      ->setReadOnly(TRUE);
-
-    // Standard field, unique outside of the scope of the current project.
-    $fields['uuid'] = BaseFieldDefinition::create('uuid')
-      ->setLabel(t('UUID'))
-      ->setDescription(t('The UUID of the EncryptedFieldValue entity.'))
-      ->setReadOnly(TRUE);
-
-    // @TODO: field language supports
-//    $fields['langcode'] = BaseFieldDefinition::create('language')
-//      ->setLabel(t('Language code'))
-//      ->setDescription(t('The language code of EncryptedFieldValue entity.'));
-
-    // @TODO: revision id
+    $fields = parent::baseFieldDefinitions($entity_type);
 
     $fields['entity_type'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Entity type'))
@@ -80,6 +56,11 @@ class EncryptedFieldValue extends ContentEntityBase implements EncryptedFieldVal
       ->setLabel(t('Entity ID'))
       ->setDescription(t('The ID of the entity for which to store the encrypted value.'))
       ->setRequired(TRUE);
+
+    $fields['entity_revision_id'] = BaseFieldDefinition::create('integer')
+      ->setLabel(t('Revision ID'))
+      ->setDescription(t('The revision ID of the entity.'))
+      ->setSetting('unsigned', TRUE);
 
     $fields['field_name'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Field name'))
@@ -97,6 +78,7 @@ class EncryptedFieldValue extends ContentEntityBase implements EncryptedFieldVal
       ->setLabel(t('Encrypted value'))
       ->setDescription(t('The encrypted value'));
       //->setTranslatable(TRUE)
+      //->setRevisionable(TRUE);
 
     return $fields;
   }

--- a/src/Entity/EncryptedFieldValueInterface.php
+++ b/src/Entity/EncryptedFieldValueInterface.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @file
+ * Contains \Drupal\field_encrypt\Entity\EncryptedFieldValueInterface.
+ */
+
+namespace Drupal\field_encrypt\Entity;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+
+/**
+ * Provides an interface defining an EncryptedFieldValue entity.
+ *
+ * @ingroup field_encrypt
+ */
+interface EncryptedFieldValueInterface extends ContentEntityInterface {
+
+  /**
+   * Get the encrypted field value.
+   *
+   * @return string
+   *   The encrypted value.
+   */
+  public function getEncryptedValue();
+
+  /**
+   * Set the encrypted field value.
+   *
+   * @param string $value
+   *   The encrypted value.
+   */
+  public function setEncryptedValue($value);
+
+}

--- a/src/FieldEncryptProcessEntities.php
+++ b/src/FieldEncryptProcessEntities.php
@@ -89,7 +89,6 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
    */
   public function encryptEntity(ContentEntityInterface $entity) {
     $this->processEntity($entity, 'encrypt');
-    return $entity;
   }
 
   /**
@@ -97,7 +96,6 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
    */
   public function decryptEntity(ContentEntityInterface $entity) {
     $this->processEntity($entity, 'decrypt');
-    return $entity;
   }
 
   /**
@@ -131,7 +129,8 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
       // Save encrypted value in EncryptedFieldValue entity.
       $this->encryptedFieldValueManager->saveEncryptedFieldValue($entity, $field->getName(), $property_name, $processed_value);
       // Return value to store for unencrypted property.
-      // @TODO: why can't this be NULL?
+      // We can't set this to NULL, because then the field values are not saved,
+      // so we can replace them with their unencrypted value on load.
       return '[ENCRYPTED]';
 
     }
@@ -142,7 +141,9 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
         $decrypted_value = $this->encryptService->decrypt(base64_decode($encrypted_value), $encryption_profile);
         return $decrypted_value;
       }
-      return '';
+      else {
+        return $value;
+      }
     }
   }
 

--- a/src/FieldEncryptProcessEntities.php
+++ b/src/FieldEncryptProcessEntities.php
@@ -14,7 +14,6 @@ use Drupal\Core\Entity\Query\QueryFactory;
 use Drupal\encrypt\EncryptionProfileInterface;
 use Drupal\encrypt\EncryptionProfileManagerInterface;
 use Drupal\encrypt\EncryptServiceInterface;
-use Drupal\field_encrypt\Entity\EncryptedFieldValueInterface;
 
 /**
  * Service class to process entities and fields for encryption.
@@ -58,7 +57,7 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
   /**
    * The EncryptedFieldValue entity manager.
    *
-   * @var \Drupal\field_encrypt\Entity\EncryptedFieldValueInterface
+   * @var \Drupal\field_encrypt\EncryptedFieldValueManagerInterface
    */
   protected $encryptedFieldValueManager;
 
@@ -73,7 +72,7 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
    *   The encryption service.
    * @param \Drupal\encrypt\EncryptionProfileManager $encryption_profile_manager
    *   The encryption profile manager.
-   * @param \Drupal\field_encrypt\Entity\EncryptedFieldValueInterface $encrypted_field_value_manager
+   * @param \Drupal\field_encrypt\EncryptedFieldValueManagerInterface $encrypted_field_value_manager
    *   The EncryptedFieldValue entity manager.
    */
   public function __construct(QueryFactory $query_factory, EntityManager $entity_manager, EncryptServiceInterface $encrypt_service, EncryptionProfileManagerInterface $encryption_profile_manager, EncryptedFieldValueManagerInterface $encrypted_field_value_manager) {
@@ -278,8 +277,13 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
       return;
     }
 
-    foreach ($entity->getFields() as $field){
-      $this->processField($entity, $field, $op);
+    // Process all language variants of the entity.
+    $languages = $entity->getTranslationLanguages();
+    foreach ($languages as $language) {
+      $translated_entity = $entity->getTranslation($language->getId());
+      foreach ($translated_entity->getFields() as $field) {
+        $this->processField($translated_entity, $field, $op);
+      }
     }
   }
 

--- a/src/FieldEncryptProcessEntitiesInterface.php
+++ b/src/FieldEncryptProcessEntitiesInterface.php
@@ -16,9 +16,21 @@ use Drupal\Core\Entity\ContentEntityInterface;
 interface FieldEncryptProcessEntitiesInterface {
 
   /**
+   * Check if entity has encrypted fields.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity to check.
+   *
+   * @return bool
+   *   TRUE if entity has encrypted fields, FALSE if not.
+   */
+  public function entityHasEncryptedFields(ContentEntityInterface $entity);
+
+  /**
    * Encrypt fields for an entity.
    *
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity to encrypt fields on.
    */
   public function encryptEntity(ContentEntityInterface $entity);
 
@@ -26,18 +38,9 @@ interface FieldEncryptProcessEntitiesInterface {
    * Decrypt fields for an entity.
    *
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity to decrypt fields on.
    */
   public function decryptEntity(ContentEntityInterface $entity);
-
-  /**
-   * Check if entity has encrypted fields.
-   *
-   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
-   *
-   * @return bool
-   *   TRUE if entity has encrypted fields, FALSE if not.
-   */
-  public function checkEntity(ContentEntityInterface $entity);
 
   /**
    * Encrypt stored fields.
@@ -62,4 +65,5 @@ interface FieldEncryptProcessEntitiesInterface {
    *   The name of the field to decrypt.
    */
   public function decryptStoredField($entity_type, $field_name);
+
 }

--- a/src/FieldEncryptProcessEntitiesInterface.php
+++ b/src/FieldEncryptProcessEntitiesInterface.php
@@ -30,6 +30,16 @@ interface FieldEncryptProcessEntitiesInterface {
   public function decryptEntity(ContentEntityInterface $entity);
 
   /**
+   * Check if entity has encrypted fields.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *
+   * @return bool
+   *   TRUE if entity has encrypted fields, FALSE if not.
+   */
+  public function checkEntity(ContentEntityInterface $entity);
+
+  /**
    * Encrypt stored fields.
    *
    * This is performed when field storage settings are updated.

--- a/src/Form/FieldEncryptSettingsForm.php
+++ b/src/Form/FieldEncryptSettingsForm.php
@@ -75,7 +75,6 @@ class FieldEncryptSettingsForm extends ConfigFormBase {
       '#tree' => TRUE,
     );
 
-
     // Gather valid field types.
     foreach ($this->fieldTypePluginManager->getGroupedDefinitions($this->fieldTypePluginManager->getUiDefinitions()) as $category => $field_types) {
 


### PR DESCRIPTION
…ntentEntity

As mentioned on IRC, this is some WIP code that tries to implement the approach laid out in https://github.com/d8-contrib-modules/field_encrypt/issues/24.

Upon the first save of a node, the fields don't actually get encrypted and will return empty.
But when you update the node, things work roughly: the real field data is set to [ENCRYPTED] currently (still need to figure out why NULL or '' doesn't work) - upon loading the entity, this is dynamically replaced with the decrypted value from the EncryptedFieldValue entity.

The batch encrypting / decypting of values when field storage settings are changed, is also pretty broken due to these updates. To be fixed once the general approach works well.
