### PR TITLE
Update entities in batch when field encryption settings change

### DIFF
--- a/config/install/field_encrypt.settings.yml
+++ b/config/install/field_encrypt.settings.yml
@@ -19,3 +19,4 @@ default_properties:
     - title
   telephone:
     - value
+batch_size: 5

--- a/config/schema/field_encrypt.schema.yml
+++ b/config/schema/field_encrypt.schema.yml
@@ -28,4 +28,6 @@ field_encrypt.settings:
         sequence:
           type: string
           label: 'Property name'
-
+    batch_size:
+      type: integer
+      label: 'Batch size'

--- a/config/schema/field_encrypt.schema.yml
+++ b/config/schema/field_encrypt.schema.yml
@@ -5,6 +5,15 @@ field.storage.*.*.third_party.field_encrypt:
     encrypt:
       type: boolean
       label: 'Encrypt'
+    properties:
+      type: sequence
+      label: 'Properties'
+      sequence:
+        type: string
+        label: 'Property'
+    encryption_profile:
+      type: string
+      label: 'Encryption profile'
 
 field_encrypt.settings:
   type: config_object

--- a/field_encrypt.module
+++ b/field_encrypt.module
@@ -80,7 +80,8 @@ function field_encrypt_form_alter(&$form, FormStateInterface $form_state, $form_
         ],
       );
 
-      // We add a function to process the form when it is saved.
+      // We add functions to process the form when it is saved.
+      $form['actions']['submit']['#submit'][] = 'field_encrypt_update_encryption_form_submit';
       $form['#entity_builders'][] = 'field_encrypt_form_field_add_form_builder';
     }
   }
@@ -100,11 +101,12 @@ function field_encrypt_form_alter(&$form, FormStateInterface $form_state, $form_
  */
 function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\Entity\FieldStorageConfig $field_storage_config, &$form, \Drupal\Core\Form\FormStateInterface $form_state) {
   $field_encryption_settings = $form_state->getValue('field_encrypt');
+  $field_encryption_settings['encrypt'] = (bool) $field_encryption_settings['encrypt'];
   $form_encryption = $field_encryption_settings['encrypt'];
   $original_encryption = $field_storage_config->getThirdPartySettings('field_encrypt');
 
   // If the form has the value, we set it.
-  if ($form_encryption === 1) {
+  if ($form_encryption) {
     foreach ($field_encryption_settings as $settings_key => $settings_value) {
       $field_storage_config->setThirdPartySetting('field_encrypt', $settings_key, $settings_value);
     }
@@ -117,21 +119,107 @@ function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\E
   }
 
   if ($original_encryption !== $field_storage_config->getThirdPartySettings('field_encrypt')) {
-    // We need to process the field to either encrypt or decrypt the stored
-    // fields if the setting was changed.
-    $field_name = $field_storage_config->get('field_name');
-    $field_entity_type = $field_storage_config->get('entity_type');
-
-    /* @var $field_encrypt_process_entities \Drupal\field_encrypt\FieldEncryptProcessEntities */
-    // @TODO: refactor logic for re-encrypting existing fields - currently broken, so commented out.
-    //    $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
-    //    if ($form_encryption === 1) {
-    //      $field_encrypt_process_entities->encryptStoredField($field_entity_type, $field_name);
-    //    }
-    //    elseif ($form_encryption === 0) {
-    //      $field_encrypt_process_entities->decryptStoredField($field_entity_type, $field_name);
-    //    }
+    // Only re-encrypt field data if this field contains actual data.
+    if ($field_storage_config->hasData()) {
+      // We need to process the field to either encrypt or decrypt the stored
+      // fields if the setting was changed.
+      $storage = $form_state->getStorage();
+      $storage['field_encrypt_update'] = TRUE;
+      $storage['field_encrypt_field_name'] = $field_storage_config->get('field_name');
+      $storage['field_encrypt_entity_type'] = $field_storage_config->get('entity_type');
+      $storage['original_encryption_settings'] = $original_encryption;
+      $form_state->setStorage($storage);
+    }
   }
+}
+
+/**
+ * Submit handler to update encryption after saving field storage settings.
+ *
+ * @param $form
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ */
+function field_encrypt_update_encryption_form_submit(&$form, FormStateInterface $form_state) {
+  $storage = $form_state->getStorage();
+  if (isset($storage['field_encrypt_update']) && $storage['field_encrypt_update'] == TRUE) {
+    $field_entity_type = $storage['field_encrypt_entity_type'];
+    $field_name = $storage['field_encrypt_field_name'];
+    $original_encryption_settings = $storage['original_encryption_settings'];
+
+    // Get entity IDs to update.
+    $entity_query = \Drupal::service('entity.query');
+    $query = $entity_query->get($field_entity_type);
+    // Check if the field is present.
+    $query->exists($field_name);
+    //$query->allRevisions();
+    $entity_ids = $query->execute();
+
+    $batch = array(
+      'title' => t('Updating field encryption'),
+      'operations' => array(
+        array('field_encrypt_update_field_encryption', array($entity_ids, $field_name, $field_entity_type, $original_encryption_settings)),
+      ),
+      'finished' => 'field_encrypt_update_field_encryption_finished',
+    );
+    batch_set($batch);
+  }
+}
+
+/**
+ * Callback for batch updating of encryption fields.
+ *
+ * @param $entity_type
+ * @param $field_name
+ * @param $context
+ */
+function field_encrypt_update_field_encryption($entity_ids, $field_name, $field_entity_type, $original_encryption_settings, &$context) {
+//  $entity_type_manager = \Drupal::service('entity_type.manager');
+  $process_entities = \Drupal::service('field_encrypt.process_entities');
+  if (empty($context['sandbox'])) {
+    $context['sandbox']['entity_ids'] = $entity_ids;
+    $context['sandbox']['progress'] = 0;
+    $context['sandbox']['max'] = count($entity_ids);
+  }
+
+  // Process entities by groups of 5.
+  //$ids_to_process = array_slice($context['sandbox']['entity_ids'], 0, 5, TRUE);
+  $count = min(5, count($context['sandbox']['entity_ids']));
+  for ($i = 1; $i <= $count; $i++) {
+    $entity_id = array_shift($context['sandbox']['entity_ids']);
+    /* @var $entity_storage Drupal\Core\Entity\EntityStorageInterface */
+    $process_entities->updateStoredField($field_name, $field_entity_type, $original_encryption_settings, $entity_id);
+    $context['results'][] = $entity_id;
+    // Update our progress information.
+    $context['sandbox']['progress']++;
+  }
+
+  // Inform the batch engine that we are not finished,
+  // and provide an estimation of the completion level we reached.
+  if ($context['sandbox']['progress'] != $context['sandbox']['max']) {
+    $context['finished'] = $context['sandbox']['progress'] / $context['sandbox']['max'];
+  }
+}
+
+/**
+ * Callback for finishing batch encryption updates of fields.
+ *
+ * @param bool $success
+ *   A boolean indicating whether the batch has completed successfully.
+ * @param array $results
+ *   The value set in $context['results'] by callback_batch_operation().
+ * @param array $operations
+ *   If $success is FALSE, contains the operations that remained unprocessed.
+ */
+function field_encrypt_update_field_encryption_finished($success, $results, $operations) {
+  // The 'success' parameter means no fatal PHP errors were detected. All
+  // other error management should be handled using 'results'.
+  if ($success) {
+    $message = \Drupal::translation()->formatPlural(count($results), 'One entity updated.', '@count entities updated.');
+  }
+  else {
+    $message = t('Finished with an error.');
+  }
+  drupal_set_message($message);
 }
 
 /**

--- a/field_encrypt.module
+++ b/field_encrypt.module
@@ -141,23 +141,27 @@ function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\E
  */
 function field_encrypt_update_encryption_form_submit(&$form, FormStateInterface $form_state) {
   $storage = $form_state->getStorage();
+  $entity_type_manager = \Drupal::service('entity_type.manager');
   if (isset($storage['field_encrypt_update']) && $storage['field_encrypt_update'] == TRUE) {
-    $field_entity_type = $storage['field_encrypt_entity_type'];
+    $entity_type_id = $storage['field_encrypt_entity_type'];
+    $entity_type = $entity_type_manager->getDefinition($entity_type_id);
     $field_name = $storage['field_encrypt_field_name'];
     $original_encryption_settings = $storage['original_encryption_settings'];
 
     // Get entity IDs to update.
     $entity_query = \Drupal::service('entity.query');
-    $query = $entity_query->get($field_entity_type);
+    $query = $entity_query->get($entity_type_id);
     // Check if the field is present.
     $query->exists($field_name);
-    //$query->allRevisions();
+    if ($entity_type->hasKey('revision')) {
+      $query->allRevisions();
+    }
     $entity_ids = $query->execute();
 
     $batch = array(
       'title' => t('Updating field encryption'),
       'operations' => array(
-        array('field_encrypt_update_field_encryption', array($entity_ids, $field_name, $field_entity_type, $original_encryption_settings)),
+        array('field_encrypt_update_field_encryption', array(array_keys($entity_ids), $field_name, $entity_type_id, $original_encryption_settings)),
       ),
       'finished' => 'field_encrypt_update_field_encryption_finished',
     );
@@ -182,7 +186,6 @@ function field_encrypt_update_field_encryption($entity_ids, $field_name, $field_
   }
 
   // Process entities by groups of 5.
-  //$ids_to_process = array_slice($context['sandbox']['entity_ids'], 0, 5, TRUE);
   $count = min(5, count($context['sandbox']['entity_ids']));
   for ($i = 1; $i <= $count; $i++) {
     $entity_id = array_shift($context['sandbox']['entity_ids']);

--- a/field_encrypt.module
+++ b/field_encrypt.module
@@ -35,7 +35,7 @@ function field_encrypt_form_alter(&$form, FormStateInterface $form_state, $form_
 
       // Display a warning about changing field data.
       if ($form_id == "field_storage_config_edit_form" && $field->hasData()) {
-        $form['field_encrypt']['#prefix'] = '<div class="messages messages--warning">' .t('Warning: changing field encryption settings may cause data corruption!<br />When changing these settings, existing fields will be (re)encrypted in batch according to the new settings. <br />Make sure you have a proper backup, and do not perform this action in an environment where the data will be changing during the batch operation, to avoid data loss.') . '</div>';
+        $form['field_encrypt']['#prefix'] = '<div class="messages messages--warning">' . t('Warning: changing field encryption settings may cause data corruption!<br />When changing these settings, existing fields will be (re)encrypted in batch according to the new settings. <br />Make sure you have a proper backup, and do not perform this action in an environment where the data will be changing during the batch operation, to avoid data loss.') . '</div>';
       }
 
       $form['field_encrypt']['field_encrypt'] = array(
@@ -106,11 +106,10 @@ function field_encrypt_form_alter(&$form, FormStateInterface $form_state, $form_
 function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\Entity\FieldStorageConfig $field_storage_config, &$form, \Drupal\Core\Form\FormStateInterface $form_state) {
   $field_encryption_settings = $form_state->getValue('field_encrypt');
   $field_encryption_settings['encrypt'] = (bool) $field_encryption_settings['encrypt'];
-  $form_encryption = $field_encryption_settings['encrypt'];
   $original_encryption = $field_storage_config->getThirdPartySettings('field_encrypt');
 
   // If the form has the value, we set it.
-  if ($form_encryption) {
+  if ($field_encryption_settings['encrypt']) {
     foreach ($field_encryption_settings as $settings_key => $settings_value) {
       $field_storage_config->setThirdPartySetting('field_encrypt', $settings_key, $settings_value);
     }
@@ -122,11 +121,13 @@ function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\E
     $field_storage_config->unsetThirdPartySetting('field_encrypt', 'encryption_profile');
   }
 
+  // Check if existing data will need to be updated when changing settings.
   if ($original_encryption !== $field_storage_config->getThirdPartySettings('field_encrypt')) {
     // Only re-encrypt field data if this field contains actual data.
     if ($field_storage_config->hasData()) {
       // We need to process the field to either encrypt or decrypt the stored
       // fields if the setting was changed.
+      // See field_encrypt_update_encryption_form_submit()
       $storage = $form_state->getStorage();
       $storage['field_encrypt_update'] = TRUE;
       $storage['field_encrypt_field_name'] = $field_storage_config->get('field_name');
@@ -140,32 +141,45 @@ function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\E
 /**
  * Submit handler to update encryption after saving field storage settings.
  *
- * @param $form
+ * @param array $form
+ *   An associative array containing the structure of the form.
  * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The current state of the form.
  */
 function field_encrypt_update_encryption_form_submit(&$form, FormStateInterface $form_state) {
   $storage = $form_state->getStorage();
   $entity_type_manager = \Drupal::service('entity_type.manager');
+  // If the flag is set to update existing fields, run a batch process to do so.
   if (isset($storage['field_encrypt_update']) && $storage['field_encrypt_update'] == TRUE) {
     $entity_type_id = $storage['field_encrypt_entity_type'];
     $entity_type = $entity_type_manager->getDefinition($entity_type_id);
     $field_name = $storage['field_encrypt_field_name'];
     $original_encryption_settings = $storage['original_encryption_settings'];
 
-    // Get entity IDs to update.
+    // Get entities that need updating, because they contain the field that has
+    // its field encryption settings updated.
     $entity_query = \Drupal::service('entity.query');
     $query = $entity_query->get($entity_type_id);
     // Check if the field is present.
     $query->exists($field_name);
+    // Make sure to get all revisions for revisionable entities.
     if ($entity_type->hasKey('revision')) {
       $query->allRevisions();
     }
     $entity_ids = $query->execute();
 
+    // Configure the batch operation to be called, with the appropriate
+    // parameters to process the loaded entity IDs that need updating.
     $batch = array(
       'title' => t('Updating field encryption'),
       'operations' => array(
-        array('field_encrypt_update_field_encryption', array(array_keys($entity_ids), $field_name, $entity_type_id, $original_encryption_settings)),
+        array('field_encrypt_update_field_encryption', array(
+          array_keys($entity_ids),
+          $field_name,
+          $entity_type_id,
+          $original_encryption_settings,
+        ),
+        ),
       ),
       'finished' => 'field_encrypt_update_field_encryption_finished',
     );
@@ -176,12 +190,18 @@ function field_encrypt_update_encryption_form_submit(&$form, FormStateInterface 
 /**
  * Callback for batch updating of encryption fields.
  *
- * @param $entity_type
- * @param $field_name
- * @param $context
+ * @param array $entity_ids
+ *   The entity IDs to update with the new field encryption settings.
+ * @param string $field_name
+ *   The name of the field that his its encryption settings changed.
+ * @param string $field_entity_type
+ *   The entity type whose field storage settings have been changed.
+ * @param array $original_encryption_settings
+ *   The original field encryption settings, before they where changed.
+ * @param array $context
+ *   The batch API context.
  */
 function field_encrypt_update_field_encryption($entity_ids, $field_name, $field_entity_type, $original_encryption_settings, &$context) {
-//  $entity_type_manager = \Drupal::service('entity_type.manager');
   $process_entities = \Drupal::service('field_encrypt.process_entities');
   if (empty($context['sandbox'])) {
     $context['sandbox']['entity_ids'] = $entity_ids;
@@ -189,8 +209,9 @@ function field_encrypt_update_field_encryption($entity_ids, $field_name, $field_
     $context['sandbox']['max'] = count($entity_ids);
   }
 
-  // Process entities by groups of 5.
-  $count = min(5, count($context['sandbox']['entity_ids']));
+  $config = \Drupal::config('field_encrypt_admin_settings');
+  // Process entities in groups. Default batch size is 5.
+  $count = min($config->get('batch_size'), count($context['sandbox']['entity_ids']));
   for ($i = 1; $i <= $count; $i++) {
     $entity_id = array_shift($context['sandbox']['entity_ids']);
     /* @var $entity_storage Drupal\Core\Entity\EntityStorageInterface */

--- a/field_encrypt.module
+++ b/field_encrypt.module
@@ -20,7 +20,6 @@ function field_encrypt_form_alter(&$form, FormStateInterface $form_state, $form_
 
     // Check permissions.
     $user = \Drupal::currentUser();
-
     if ($user->hasPermission('administer field encryption')) {
       /* @var $field \Drupal\field\Entity\FieldStorageConfig */
       $field = $form_state->getFormObject()->getEntity();
@@ -33,6 +32,11 @@ function field_encrypt_form_alter(&$form, FormStateInterface $form_state, $form_
         '#title' => t('Field encryption'),
         '#open' => TRUE,
       );
+
+      // Display a warning about changing field data.
+      if ($form_id == "field_storage_config_edit_form" && $field->hasData()) {
+        $form['field_encrypt']['#prefix'] = '<div class="messages messages--warning">' .t('Warning: changing field encryption settings may cause data corruption!<br />When changing these settings, existing fields will be (re)encrypted in batch according to the new settings. <br />Make sure you have a proper backup, and do not perform this action in an environment where the data will be changing during the batch operation, to avoid data loss.') . '</div>';
+      }
 
       $form['field_encrypt']['field_encrypt'] = array(
         '#type' => 'container',

--- a/field_encrypt.module
+++ b/field_encrypt.module
@@ -217,7 +217,7 @@ function field_encrypt_update_field_encryption_finished($success, $results, $ope
   // The 'success' parameter means no fatal PHP errors were detected. All
   // other error management should be handled using 'results'.
   if ($success) {
-    $message = \Drupal::translation()->formatPlural(count($results), 'One entity updated.', '@count entities updated.');
+    $message = \Drupal::translation()->formatPlural(count($results), 'One field updated.', '@count fields updated.');
   }
   else {
     $message = t('Finished with an error.');
@@ -232,9 +232,10 @@ function field_encrypt_update_field_encryption_finished($success, $results, $ope
  */
 function field_encrypt_entity_insert(EntityInterface $entity) {
   // Save the entity again, but now encrypted.
-  // @TODO: check if there's not a cleaner way to do this.
-  $saved_entity = entity_load($entity->getEntityTypeId(), $entity->id());
-  field_encrypt_entity_encrypt($saved_entity);
+  if (field_encrypt_allow_encryption($entity)) {
+    $saved_entity = entity_load($entity->getEntityTypeId(), $entity->id());
+    field_encrypt_entity_encrypt($saved_entity);
+  }
 }
 
 /**

--- a/field_encrypt.services.yml
+++ b/field_encrypt.services.yml
@@ -1,7 +1,7 @@
 services:
   field_encrypt.process_entities:
     class: Drupal\field_encrypt\FieldEncryptProcessEntities
-    arguments: ['@entity.query', '@entity.manager', '@encryption', '@encrypt.encryption_profile.manager', '@field_encrypt.encrypted_field_value_manager']
+    arguments: ['@entity.query', '@entity_type.manager', '@encryption', '@encrypt.encryption_profile.manager', '@field_encrypt.encrypted_field_value_manager']
 
   field_encrypt.encrypted_field_value_manager:
     class: Drupal\field_encrypt\EncryptedFieldValueManager

--- a/src/EncryptedFieldValueManager.php
+++ b/src/EncryptedFieldValueManager.php
@@ -126,6 +126,20 @@ class EncryptedFieldValueManager implements EncryptedFieldValueManagerInterface 
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function deleteEncryptedFieldValuesForField($entity, $field_name) {
+    $field_values = $this->entityManager->getStorage('encrypted_field_value')->loadByProperties([
+      'entity_type' => $entity->getEntityTypeId(),
+      'field_name' => $field_name,
+      'entity_revision_id' => $this->getEntityRevisionId($entity),
+    ]);
+    if ($field_values) {
+      $this->entityManager->getStorage('encrypted_field_value')->delete($field_values);
+    }
+  }
+
+  /**
    * Get the revision ID to store for a given entity.
    *
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity
@@ -142,19 +156,6 @@ class EncryptedFieldValueManager implements EncryptedFieldValueManagerInterface 
       $revision_id = $entity->id();
     }
     return $revision_id;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function deleteEncryptedFieldValuesForField($entity_type, $field_name) {
-    $field_values = $this->entityManager->getStorage('encrypted_field_value')->loadByProperties([
-      'entity_type' => $entity_type,
-      'field_name' => $field_name,
-    ]);
-    if ($field_values) {
-      $this->entityManager->getStorage('encrypted_field_value')->delete($field_values);
-    }
   }
 
 }

--- a/src/EncryptedFieldValueManager.php
+++ b/src/EncryptedFieldValueManager.php
@@ -144,4 +144,17 @@ class EncryptedFieldValueManager implements EncryptedFieldValueManagerInterface 
     return $revision_id;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function deleteEncryptedFieldValuesForField($entity_type, $field_name) {
+    $field_values = $this->entityManager->getStorage('encrypted_field_value')->loadByProperties([
+      'entity_type' => $entity_type,
+      'field_name' => $field_name,
+    ]);
+    if ($field_values) {
+      $this->entityManager->getStorage('encrypted_field_value')->delete($field_values);
+    }
+  }
+
 }

--- a/src/EncryptedFieldValueManager.php
+++ b/src/EncryptedFieldValueManager.php
@@ -47,9 +47,9 @@ class EncryptedFieldValueManager implements EncryptedFieldValueManagerInterface 
   /**
    * {@inheritdoc}
    */
-  public function saveEncryptedFieldValue(ContentEntityInterface $entity, $field_name, $property, $encrypted_value) {
+  public function saveEncryptedFieldValue(ContentEntityInterface $entity, $field_name, $delta, $property, $encrypted_value) {
     $langcode = $entity->language()->getId();
-    if ($encrypted_field_value = $this->getExistingEntity($entity, $field_name, $property)) {
+    if ($encrypted_field_value = $this->getExistingEntity($entity, $field_name, $delta, $property)) {
       $translation = $encrypted_field_value->hasTranslation($langcode) ? $encrypted_field_value->getTranslation($langcode) : $encrypted_field_value->addTranslation($langcode);
       $translation->setEncryptedValue($encrypted_value);
     }
@@ -60,6 +60,7 @@ class EncryptedFieldValueManager implements EncryptedFieldValueManagerInterface 
         'entity_revision_id' => $this->getEntityRevisionId($entity),
         'field_name' => $field_name,
         'field_property' => $property,
+        'field_delta' => $delta,
         'encrypted_value' => $encrypted_value,
         'langcode' => $langcode,
       ]);
@@ -71,8 +72,8 @@ class EncryptedFieldValueManager implements EncryptedFieldValueManagerInterface 
   /**
    * {@inheritdoc}
    */
-  public function getEncryptedFieldValue(ContentEntityInterface $entity, $field_name, $property) {
-    $field_value_entity = $this->getExistingEntity($entity, $field_name, $property);
+  public function getEncryptedFieldValue(ContentEntityInterface $entity, $field_name, $delta, $property) {
+    $field_value_entity = $this->getExistingEntity($entity, $field_name, $delta, $property);
     if ($field_value_entity) {
       $langcode = $entity->language()->getId();
       if ($field_value_entity->hasTranslation($langcode)) {
@@ -90,18 +91,21 @@ class EncryptedFieldValueManager implements EncryptedFieldValueManagerInterface 
    *   The entity to check.
    * @param string $field_name
    *   The field name to check.
+   * @param int $delta
+   *   The field delta to check.
    * @param string $property
    *   The field property to check.
    *
    * @return bool|\Drupal\field_encrypt\Entity\EncryptedFieldValue
    *   The existing EncryptedFieldValue entity.
    */
-  protected function getExistingEntity(ContentEntityInterface $entity, $field_name, $property) {
+  protected function getExistingEntity(ContentEntityInterface $entity, $field_name, $delta, $property) {
     $query = $this->entityQuery->get('encrypted_field_value')
       ->condition('entity_type', $entity->getEntityTypeId())
       ->condition('entity_id', $entity->id())
       ->condition('entity_revision_id', $this->getEntityRevisionId($entity))
       ->condition('field_name', $field_name)
+      ->condition('field_delta', $delta)
       ->condition('field_property', $property);
     $values = $query->execute();
 

--- a/src/EncryptedFieldValueManagerInterface.php
+++ b/src/EncryptedFieldValueManagerInterface.php
@@ -23,7 +23,7 @@ interface EncryptedFieldValueManagerInterface {
    *   The entity to process.
    * @param string $field_name
    *   The field name to save.
-   * @param int delta
+   * @param int $delta
    *   The field delta to save.
    * @param string $property
    *   The field property to save.
@@ -39,7 +39,7 @@ interface EncryptedFieldValueManagerInterface {
    *   The entity to process.
    * @param string $field_name
    *   The field name to retrieve.
-   * @param int delta
+   * @param int $delta
    *   The field delta to retrieve.
    * @param string $property
    *   The field property to retrieve.
@@ -65,5 +65,6 @@ interface EncryptedFieldValueManagerInterface {
    * @param string $field_name
    *   The field name to delete encrypted values for.
    */
-  public function deleteEncryptedFieldValuesForField($entity, $field_name);
+  public function deleteEncryptedFieldValuesForField(ContentEntityInterface $entity, $field_name);
+
 }

--- a/src/EncryptedFieldValueManagerInterface.php
+++ b/src/EncryptedFieldValueManagerInterface.php
@@ -56,10 +56,10 @@ interface EncryptedFieldValueManagerInterface {
   /**
    * Delete encrypted field values for a given field.
    *
-   * @param string $entity_type
-   *   The entity type ID.
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity containing the field to be deleted.
    * @param string $field_name
    *   The field name to delete encrypted values for.
    */
-  public function deleteEncryptedFieldValuesForField($entity_type, $field_name);
+  public function deleteEncryptedFieldValuesForField($entity, $field_name);
 }

--- a/src/EncryptedFieldValueManagerInterface.php
+++ b/src/EncryptedFieldValueManagerInterface.php
@@ -23,12 +23,14 @@ interface EncryptedFieldValueManagerInterface {
    *   The entity to process.
    * @param string $field_name
    *   The field name to save.
+   * @param int delta
+   *   The field delta to save.
    * @param string $property
    *   The field property to save.
    * @param string $encrypted_value
    *   The encrypted value to save.
    */
-  public function saveEncryptedFieldValue(ContentEntityInterface $entity, $field_name, $property, $encrypted_value);
+  public function saveEncryptedFieldValue(ContentEntityInterface $entity, $field_name, $delta, $property, $encrypted_value);
 
   /**
    * Get an encrypted field value.
@@ -37,13 +39,15 @@ interface EncryptedFieldValueManagerInterface {
    *   The entity to process.
    * @param string $field_name
    *   The field name to retrieve.
+   * @param int delta
+   *   The field delta to retrieve.
    * @param string $property
    *   The field property to retrieve.
    *
    * @return string
    *   The encrypted field value.
    */
-  public function getEncryptedFieldValue(ContentEntityInterface $entity, $field_name, $property);
+  public function getEncryptedFieldValue(ContentEntityInterface $entity, $field_name, $delta, $property);
 
   /**
    * Delete encrypted field values for a given entity.

--- a/src/EncryptedFieldValueManagerInterface.php
+++ b/src/EncryptedFieldValueManagerInterface.php
@@ -53,4 +53,13 @@ interface EncryptedFieldValueManagerInterface {
    */
   public function deleteEncryptedFieldValues(ContentEntityInterface $entity);
 
+  /**
+   * Delete encrypted field values for a given field.
+   *
+   * @param string $entity_type
+   *   The entity type ID.
+   * @param string $field_name
+   *   The field name to delete encrypted values for.
+   */
+  public function deleteEncryptedFieldValuesForField($entity_type, $field_name);
 }

--- a/src/Entity/EncryptedFieldValue.php
+++ b/src/Entity/EncryptedFieldValue.php
@@ -62,6 +62,11 @@ class EncryptedFieldValue extends ContentEntityBase implements EncryptedFieldVal
       ->setSetting('is_ascii', TRUE)
       ->setSetting('max_length', FieldStorageConfig::NAME_MAX_LENGTH);
 
+    $fields['field_delta'] = BaseFieldDefinition::create('integer')
+      ->setLabel(t('Field delta'))
+      ->setDescription(t('The field delta.'))
+      ->setSetting('unsigned', TRUE);
+
     $fields['field_property'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Field property'))
       ->setDescription(t('The field property for which to store the encrypted value.'))

--- a/src/FieldEncryptProcessEntities.php
+++ b/src/FieldEncryptProcessEntities.php
@@ -315,10 +315,12 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
     $languages = $entity->getTranslationLanguages();
     foreach ($languages as $language) {
       $this->updatingStoredField = $field_name;
-      $translated_entity = $entity->getTranslation($language->getId());
-      $this->processStoredField($translated_entity, $field_name, $original_encryption_settings);
+      $entity = $entity->getTranslation($language->getId());
+      $this->processStoredField($entity, $field_name, $original_encryption_settings);
     }
-
+    // Set flag to trigger field encryption in field_encrypt_entity_presave().
+    $entity->doFieldEncryption = TRUE;
+    $entity->save();
   }
 
   /**
@@ -346,8 +348,5 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
 
     // Remove flag that avoids processing field on load, since we want to save.
     $this->updatingStoredField = FALSE;
-    // Set flag to trigger field encryption in field_encrypt_entity_presave().
-    $entity->doFieldEncryption = TRUE;
-    $entity->save();
   }
 }

--- a/src/FieldEncryptProcessEntities.php
+++ b/src/FieldEncryptProcessEntities.php
@@ -303,7 +303,14 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
     $this->updatingStoredField = $field_name;
 
     $entity_storage = $this->entityManager->getStorage($field_entity_type);
-    $entity = $entity_storage->load($entity_id);
+    // Check if entity allows revisions.
+    if ($this->entityManager->getDefinition($field_entity_type)->hasKey('revision')) {
+      $entity = $entity_storage->loadRevision($entity_id);
+    }
+    else {
+      $entity = $entity_storage->load($entity_id);
+    }
+
     $field = $entity->get($field_name);
     // Decrypt with original settings.
     $this->processField($entity, $field, 'decrypt', TRUE, $original_encryption_settings);

--- a/src/FieldEncryptProcessEntities.php
+++ b/src/FieldEncryptProcessEntities.php
@@ -171,7 +171,7 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
     if (!$update) {
       // Check if we are updating the field, in that case, skip it now (during
       // the initial entity load.
-      if ($this->updatingStoredField === $definition->get('field_name')) {
+      if ($op == "decrypt" && $this->updatingStoredField === $definition->get('field_name')) {
         return;
       }
 
@@ -347,6 +347,6 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
     }
 
     // Remove flag that avoids processing field on load, since we want to save.
-    $this->updatingStoredField = FALSE;
+    //$this->updatingStoredField = FALSE;
   }
 }

--- a/src/FieldEncryptProcessEntitiesInterface.php
+++ b/src/FieldEncryptProcessEntitiesInterface.php
@@ -51,7 +51,7 @@ interface FieldEncryptProcessEntitiesInterface {
    *   The entity type to update.
    * @param array $original_encryption_settings
    *   Array with original encryption settings to decrypt current values.
-   * @param $entity_id
+   * @param int $entity_id
    *   The entity (revision) ID to update.
    */
   public function updateStoredField($field_name, $field_entity_type, $original_encryption_settings, $entity_id);

--- a/src/FieldEncryptProcessEntitiesInterface.php
+++ b/src/FieldEncryptProcessEntitiesInterface.php
@@ -43,27 +43,17 @@ interface FieldEncryptProcessEntitiesInterface {
   public function decryptEntity(ContentEntityInterface $entity);
 
   /**
-   * Encrypt stored fields.
+   * Update the encryption settings on a stored field.
    *
-   * This is performed when field storage settings are updated.
-   *
-   * @param string $entity_type
-   *   The entity type.
    * @param string $field_name
-   *   The name of the field to encrypt.
+   *   The field name to update.
+   * @param string $field_entity_type
+   *   The entity type to update.
+   * @param array $original_encryption_settings
+   *   Array with original encryption settings to decrypt current values.
+   * @param $entity_id
+   *   The entity (revision) ID to update.
    */
-  public function encryptStoredField($entity_type, $field_name);
-
-  /**
-   * Decrypt stored fields.
-   *
-   * This is performed when field storage settings are updated.
-   *
-   * @param string $entity_type
-   *   The entity type.
-   * @param string $field_name
-   *   The name of the field to decrypt.
-   */
-  public function decryptStoredField($entity_type, $field_name);
+  public function updateStoredField($field_name, $field_entity_type, $original_encryption_settings, $entity_id);
 
 }

--- a/src/Form/FieldEncryptSettingsForm.php
+++ b/src/Form/FieldEncryptSettingsForm.php
@@ -69,10 +69,11 @@ class FieldEncryptSettingsForm extends ConfigFormBase {
     $default_properties = $config->get('default_properties');
 
     $form['default_properties'] = array(
-      '#type' => 'container',
+      '#type' => 'details',
       '#title' => $this->t('Default properties'),
-      '#title_display' => FALSE,
+      '#description' => $this->t('Select which field properties will be checked by default on the field encryption settings form, per field type. Note that this does not change existing field settings, but merely sets sensible defaults.'),
       '#tree' => TRUE,
+      '#open' => TRUE,
     );
 
     // Gather valid field types.
@@ -100,6 +101,20 @@ class FieldEncryptSettingsForm extends ConfigFormBase {
           '#default_value' => isset($default_properties[$name]) ? $default_properties[$name] : [],
         ];
       }
+
+      $form['batch_update'] = array(
+        '#type' => 'details',
+        '#title' => $this->t('Batch update settings'),
+        '#description' => $this->t('Configure behaviour of the batch field update feature. When changing field encryption settings for fields that already contain data, a batch process will be started that updates the existing field values according to the new settings.'),
+        '#open' => TRUE,
+      );
+
+      $form['batch_update']['batch_size'] = array(
+        '#type' => 'number',
+        '#title' => $this->t('Batch size'),
+        '#default_value' => $config->get('batch_size'),
+        '#description' => $this->t('Specify the number of entities to process on each field update batch execution. It is recommended to keep this number low, to avoid timeouts.'),
+      );
     }
 
     return $form;
@@ -120,6 +135,7 @@ class FieldEncryptSettingsForm extends ConfigFormBase {
 
     $this->config('field_encrypt.settings')
       ->set('default_properties', $default_properties)
+      ->set('batch_size', $form_state->getValue('batch_size'))
       ->save();
 
     parent::submitForm($form, $form_state);

--- a/src/Tests/FieldEncryptTest.php
+++ b/src/Tests/FieldEncryptTest.php
@@ -1,0 +1,440 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\field_encrypt\Tests\FieldEncryptTest.
+ */
+
+namespace Drupal\field_encrypt\Tests;
+
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\encrypt\Entity\EncryptionProfile;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\field_encrypt\Entity\EncryptedFieldValue;
+use Drupal\key\Entity\Key;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\node\Entity\Node;
+use Drupal\simpletest\WebTestBase;
+
+
+/**
+ * Tests field encryption.
+ *
+ * @group field_encrypt
+ */
+class FieldEncryptTest extends WebTestBase {
+
+  /**
+   * Modules to enable for this test.
+   *
+   * @var string[]
+   */
+  public static $modules = [
+    'node',
+    'field',
+    'field_ui',
+    'text',
+    'locale',
+    'content_translation',
+    'key',
+    'encrypt',
+    'encrypt_test',
+    'field_encrypt',
+  ];
+
+  /**
+   * An administrator user.
+   *
+   * @var \Drupal\user\Entity\User
+   */
+  protected $adminUser;
+
+
+  /**
+   * A list of test keys.
+   *
+   * @var \Drupal\key\Entity\Key[]
+   */
+  protected $keys;
+
+  /**
+   * A list of test encryption profiles.
+   *
+   * @var \Drupal\encrypt\Entity\EncryptionProfile[]
+   */
+  protected $encryptionProfiles;
+
+  /**
+   * The page node type.
+   *
+   * @var \Drupal\node\NodeTypeInterface
+   */
+  protected $nodeType;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    // Create an admin user.
+    $this->adminUser = $this->drupalCreateUser([
+      'access administration pages',
+      'administer encrypt',
+      'administer keys',
+      'administer field encryption',
+    ], NULL, TRUE);
+    $this->drupalLogin($this->adminUser);
+
+    // Create test keys for encryption.
+    $key_128 = Key::create([
+      'id' => 'key_128',
+      'label' => 'Test Key 128 bit',
+      'key_type' => "encryption",
+      'key_type_settings[key_size]' => '128',
+      'key_provider' => 'config',
+      'key_input_settings[key_value]' => 'mustbesixteenbit',
+    ]);
+    $key_128->save();
+    $this->keys['key_128'] = $key_128;
+
+    $key_256 = Key::create([
+      'id' => 'key_256',
+      'label' => 'Test Key 256 bit',
+      'key_type' => "encryption",
+      'key_type_settings[key_size]' => '256',
+      'key_provider' => 'config',
+      'key_input_settings[key_value]' => 'mustbesixteenbitmustbesixteenbit',
+    ]);
+    $key_256->save();
+    $this->keys['key_256'] = $key_256;
+
+    // Create test encryption profiles.
+    $encryption_profile_1 = EncryptionProfile::create([
+      'id' => 'encryption_profile_1',
+      'label' => 'Encryption profile 1',
+      'encryption_method' => 'test_encryption_method',
+      'encryption_key' => $this->keys['key_128']->id(),
+    ]);
+    $encryption_profile_1->save();
+    $this->encryptionProfiles['encryption_profile_1'] = $encryption_profile_1;
+
+    $encryption_profile_2 = EncryptionProfile::create([
+      'id' => 'encryption_profile_2',
+      'label' => 'Encryption profile 2',
+      'encryption_method' => 'config_test_encryption_method',
+      'encryption_method_configuration[mode]' => 'CFB',
+      'encryption_key' => $this->keys['key_256']->id(),
+    ]);
+    $encryption_profile_2->save();
+    $this->encryptionProfiles['encryption_profile_2'] = $encryption_profile_2;
+
+    // Create content type to test.
+    $this->nodeType = $this->drupalCreateContentType(['type' => 'page', 'name' => 'Basic page']);
+
+    // Create test fields.
+    $single_field_storage = FieldStorageConfig::create(array(
+      'field_name' => 'field_test_single',
+      'entity_type' => 'node',
+      'type' => 'text_with_summary',
+      'cardinality' => 1,
+      'field_encrypt' => [
+        'encrypt' => 1,
+        ''
+      ]
+    ));
+    $single_field_storage->save();
+    $single_field = FieldConfig::create([
+      'field_storage' => $single_field_storage,
+      'bundle' => 'page',
+      'label' => 'Single field'
+    ]);
+    $single_field->save();
+    entity_get_form_display('node', 'page', 'default')
+      ->setComponent('field_test_single')
+      ->save();
+    entity_get_display('node', 'page', 'default')
+      ->setComponent('field_test_single', array(
+        'type' => 'text_default',
+      ))
+      ->save();
+
+    $multi_field_storage = FieldStorageConfig::create(array(
+      'field_name' => 'field_test_multi',
+      'entity_type' => 'node',
+      'type' => 'string',
+      'cardinality' => 3,
+    ));
+    $multi_field_storage->save();
+    $multi_field = FieldConfig::create([
+      'field_storage' => $multi_field_storage,
+      'bundle' => 'page',
+      'label' => 'Multi field'
+    ]);
+    $multi_field->save();
+    entity_get_form_display('node', 'page', 'default')
+      ->setComponent('field_test_multi')
+      ->save();
+    entity_get_display('node', 'page', 'default')
+      ->setComponent('field_test_multi', array(
+        'type' => 'string',
+      ))
+      ->save();
+  }
+
+  /**
+   * Test encrypting fields.
+   */
+  public function testEncryptField() {
+    $this->setFieldStorageSettings();
+
+    // Save test entity.
+    $test_node = Node::create([
+      'title' => $this->randomMachineName(8),
+      'type' => 'page',
+      'field_test_single' => [
+        [
+          'value' => "Lorem ipsum dolor sit amet.",
+          'summary' => "Lorem ipsum",
+          'format' => filter_default_format(),
+        ]
+      ],
+      'field_test_multi' => [
+        ['value' => "one"],
+        ['value' => "two"],
+        ['value' => "three"],
+      ],
+    ]);
+    $test_node->enforceIsNew(TRUE);
+    $test_node->save();
+
+    $fields = $test_node->getFields();
+    // Check field_test_single settings.
+    $single_field = $fields['field_test_single'];
+    $definition = $single_field->getFieldDefinition();
+    $this->assertTrue($definition instanceof FieldDefinitionInterface);
+    $storage = $definition->get('fieldStorage');
+    $this->assertEqual(TRUE, $storage->getThirdPartySetting('field_encrypt', 'encrypt', FALSE));
+    $this->assertEqual(['value' => 'value', 'summary' => 'summary'], array_filter($storage->getThirdPartySetting('field_encrypt', 'properties', [])));
+    $this->assertEqual('encryption_profile_1', $storage->getThirdPartySetting('field_encrypt', 'encryption_profile', ''));
+
+    // Check field_test_multi settings.
+    $single_field = $fields['field_test_multi'];
+    $definition = $single_field->getFieldDefinition();
+    $this->assertTrue($definition instanceof FieldDefinitionInterface);
+    $storage = $definition->get('fieldStorage');
+    $this->assertEqual(TRUE, $storage->getThirdPartySetting('field_encrypt', 'encrypt', FALSE));
+    $this->assertEqual(['value' => 'value'], array_filter($storage->getThirdPartySetting('field_encrypt', 'properties', [])));
+    $this->assertEqual('encryption_profile_2', $storage->getThirdPartySetting('field_encrypt', 'encryption_profile', ''));
+
+    // Check existence of EncryptedFieldValue entities.
+    $encrypted_field_values = EncryptedFieldValue::loadMultiple();
+    $this->assertEqual(5, count($encrypted_field_values));
+
+    // Check if text is displayed unencrypted.
+    $this->drupalGet('node/' . $test_node->id());
+    $this->assertText("Lorem ipsum dolor sit amet.");
+    $this->assertText("one");
+    $this->assertText("two");
+    $this->assertText("three");
+
+    $result = \Drupal::database()->query("SELECT field_test_single_value FROM {node__field_test_single} WHERE entity_id = :entity_id", array(':entity_id' => $test_node->id()))->fetchField();
+    $this->assertEqual("[ENCRYPTED]", $result);
+
+    $result = \Drupal::database()->query("SELECT field_test_multi_value FROM {node__field_test_multi} WHERE entity_id = :entity_id", array(':entity_id' => $test_node->id()))->fetchAll();
+    foreach ($result as $record) {
+      $this->assertEqual("[ENCRYPTED]", $record->field_test_multi_value);
+    }
+  }
+
+  /**
+   * Test encrypting fields with revisions.
+   */
+  public function testEncryptFieldRevision() {
+    $this->setFieldStorageSettings();
+
+    // Save test entity.
+    $test_node = Node::create([
+      'title' => $this->randomMachineName(8),
+      'type' => 'page',
+      'field_test_single' => [
+        [
+          'value' => "Lorem ipsum dolor sit amet.",
+          'summary' => "Lorem ipsum",
+          'format' => filter_default_format(),
+        ]
+      ],
+      'field_test_multi' => [
+        ['value' => "one"],
+        ['value' => "two"],
+        ['value' => "three"],
+      ],
+    ]);
+    $test_node->enforceIsNew(TRUE);
+    $test_node->save();
+
+    // Create a new revision for the entity.
+    $old_revision_id = $test_node->getRevisionId();
+    $test_node->setNewRevision(TRUE);
+    $test_node->field_test_single->value = "Lorem ipsum dolor sit amet revisioned.";
+    $test_node->field_test_single->summary = "Lorem ipsum revisioned.";
+    $multi_field = $test_node->get('field_test_multi');
+    $multi_field_value = $multi_field->getValue();
+    $multi_field_value[0]['value'] = "four";
+    $multi_field_value[1]['value'] = "five";
+    $multi_field_value[2]['value'] = "six";
+    $multi_field->setValue($multi_field_value);
+    $test_node->save();
+
+    // Check existence of EncryptedFieldValue entities.
+    $encrypted_field_values = EncryptedFieldValue::loadMultiple();
+    $this->assertEqual(10, count($encrypted_field_values));
+
+    // Check if revisioned text is displayed unencrypted.
+    $this->drupalGet('node/' . $test_node->id());
+    $this->assertText("Lorem ipsum dolor sit amet revisioned.");
+    $this->assertText("four");
+    $this->assertText("five");
+    $this->assertText("six");
+
+    // Check if original text is displayed unencrypted.
+    $this->drupalGet('node/' . $test_node->id() . '/revisions/' . $old_revision_id . '/view');
+    $this->assertText("Lorem ipsum dolor sit amet.");
+    $this->assertText("one");
+    $this->assertText("two");
+    $this->assertText("three");
+
+    $result = \Drupal::database()->query("SELECT field_test_single_value FROM {node_revision__field_test_single} WHERE entity_id = :entity_id", array(':entity_id' => $test_node->id()))->fetchField();
+    $this->assertEqual("[ENCRYPTED]", $result);
+
+    $result = \Drupal::database()->query("SELECT field_test_multi_value FROM {node_revision__field_test_multi} WHERE entity_id = :entity_id", array(':entity_id' => $test_node->id()))->fetchAll();
+    foreach ($result as $record) {
+      $this->assertEqual("[ENCRYPTED]", $record->field_test_multi_value);
+    }
+  }
+
+  /**
+   * Test encrypting fields with translations.
+   */
+  public function testEncryptFieldTranslation() {
+    $this->setTranslationSettings();
+    $this->setFieldStorageSettings();
+
+    // Save test entity.
+    $test_node = Node::create([
+      'title' => $this->randomMachineName(8),
+      'type' => 'page',
+      'field_test_single' => [
+        [
+          'value' => "This is some english text.",
+          'summary' => "English text",
+          'format' => filter_default_format(),
+        ]
+      ],
+      'field_test_multi' => [
+        ['value' => "one"],
+        ['value' => "two"],
+        ['value' => "three"],
+      ],
+      'langcode' => \Drupal::languageManager()->getDefaultLanguage()->getId(),
+    ]);
+    $test_node->enforceIsNew(TRUE);
+    $test_node->save();
+
+    // Add translated values.
+    $translated_values = [
+      'title' => $this->randomMachineName(8),
+      'field_test_single' => [
+        [
+          'value' => "Ceci est un text francais.",
+          'summary' => "Text francais",
+          'format' => filter_default_format(),
+        ]
+      ],
+      'field_test_multi' => [
+        ['value' => "un"],
+        ['value' => "deux"],
+        ['value' => "trois"],
+      ],
+    ];
+    $test_node->addTranslation('fr', $translated_values);
+    $test_node->save();
+
+    // Check existence of EncryptedFieldValue entities.
+    $encrypted_field_values = EncryptedFieldValue::loadMultiple();
+    $this->assertEqual(5, count($encrypted_field_values));
+
+    // Check if English text is displayed unencrypted.
+    $this->drupalGet('node/' . $test_node->id());
+    $this->assertText("This is some english text.");
+    $this->assertText("one");
+    $this->assertText("two");
+    $this->assertText("three");
+
+    // Check if English text is displayed unencrypted.
+    $this->drupalGet('fr/node/' . $test_node->id());
+    $this->assertText("Ceci est un text francais.");
+    $this->assertText("un");
+    $this->assertText("deux");
+    $this->assertText("trois");
+
+    $result = \Drupal::database()->query("SELECT field_test_single_value FROM {node__field_test_single} WHERE entity_id = :entity_id", array(':entity_id' => $test_node->id()))->fetchAll();
+    foreach ($result as $record) {
+      $this->assertEqual("[ENCRYPTED]", $record->field_test_single_value);
+    }
+
+    $result = \Drupal::database()->query("SELECT field_test_multi_value FROM {node__field_test_multi} WHERE entity_id = :entity_id", array(':entity_id' => $test_node->id()))->fetchAll();
+    foreach ($result as $record) {
+      $this->assertEqual("[ENCRYPTED]", $record->field_test_multi_value);
+    }
+  }
+
+  /**
+   * Set up storage settings for test fields.
+   */
+  protected function setFieldStorageSettings() {
+    // Set up storage settings for first field.
+    $this->drupalGet('admin/structure/types/manage/page/fields/node.page.field_test_single/storage');
+    $this->assertFieldByName('field_encrypt[encrypt]', NULL, 'Encrypt field found.');
+    $this->assertFieldByName('field_encrypt[encryption_profile]', NULL, 'Encryption profile field found.');
+
+    $edit = [
+      'field_encrypt[encrypt]' => 1,
+      'field_encrypt[properties][value]' => 'value',
+      'field_encrypt[properties][summary]' => 'summary',
+      'field_encrypt[encryption_profile]' => 'encryption_profile_1',
+    ];
+    $this->drupalPostForm(NULL, $edit, t('Save field settings'));
+
+    // Set up storage settings for second field.
+    $this->drupalGet('admin/structure/types/manage/page/fields/node.page.field_test_multi/storage');
+    $this->assertFieldByName('field_encrypt[encrypt]', NULL, 'Encrypt field found.');
+    $this->assertFieldByName('field_encrypt[encryption_profile]', NULL, 'Encryption profile field found.');
+
+    $edit = [
+      'field_encrypt[encrypt]' => 1,
+      'field_encrypt[properties][value]' => 'value',
+      'field_encrypt[encryption_profile]' => 'encryption_profile_2',
+    ];
+    $this->drupalPostForm(NULL, $edit, t('Save field settings'));
+  }
+
+  /**
+   * Set up translation settings for content translation test.
+   */
+  protected function setTranslationSettings() {
+    // Set up extra language.
+    ConfigurableLanguage::createFromLangcode('fr')->save();
+    // Enable translation for the current entity type and ensure the change is
+    // picked up.
+    \Drupal::service('content_translation.manager')
+      ->setEnabled('node', 'page', TRUE);
+    drupal_static_reset();
+    \Drupal::entityManager()->clearCachedDefinitions();
+    \Drupal::service('router.builder')->rebuild();
+    \Drupal::service('entity.definition_update_manager')->applyUpdates();
+    $this->rebuildContainer();
+  }
+
+}

--- a/src/Tests/FieldEncryptTest.php
+++ b/src/Tests/FieldEncryptTest.php
@@ -139,16 +139,12 @@ class FieldEncryptTest extends WebTestBase {
       'entity_type' => 'node',
       'type' => 'text_with_summary',
       'cardinality' => 1,
-      'field_encrypt' => [
-        'encrypt' => 1,
-        ''
-      ]
     ));
     $single_field_storage->save();
     $single_field = FieldConfig::create([
       'field_storage' => $single_field_storage,
       'bundle' => 'page',
-      'label' => 'Single field'
+      'label' => 'Single field',
     ]);
     $single_field->save();
     entity_get_form_display('node', 'page', 'default')
@@ -170,7 +166,7 @@ class FieldEncryptTest extends WebTestBase {
     $multi_field = FieldConfig::create([
       'field_storage' => $multi_field_storage,
       'bundle' => 'page',
-      'label' => 'Multi field'
+      'label' => 'Multi field',
     ]);
     $multi_field->save();
     entity_get_form_display('node', 'page', 'default')
@@ -198,7 +194,7 @@ class FieldEncryptTest extends WebTestBase {
           'value' => "Lorem ipsum dolor sit amet.",
           'summary' => "Lorem ipsum",
           'format' => filter_default_format(),
-        ]
+        ],
       ],
       'field_test_multi' => [
         ['value' => "one"],
@@ -263,7 +259,7 @@ class FieldEncryptTest extends WebTestBase {
           'value' => "Lorem ipsum dolor sit amet.",
           'summary' => "Lorem ipsum",
           'format' => filter_default_format(),
-        ]
+        ],
       ],
       'field_test_multi' => [
         ['value' => "one"],
@@ -330,7 +326,7 @@ class FieldEncryptTest extends WebTestBase {
           'value' => "This is some english text.",
           'summary' => "English text",
           'format' => filter_default_format(),
-        ]
+        ],
       ],
       'field_test_multi' => [
         ['value' => "one"],
@@ -350,7 +346,7 @@ class FieldEncryptTest extends WebTestBase {
           'value' => "Ceci est un text francais.",
           'summary' => "Text francais",
           'format' => filter_default_format(),
-        ]
+        ],
       ],
       'field_test_multi' => [
         ['value' => "un"],


### PR DESCRIPTION
This PR fixes the following:
- Re-enable the functionality to update fields when the encryption settings get changed, that was disabled in the last PR (https://github.com/d8-contrib-modules/field_encrypt/pull/25)
- Implement Batch API to update the entities in groups of 5 after field storage settings are changed.

This has been tested with the following scenario's:
- Non-encrypted field gets encryption --> plain text data gets encrypted
- Encrypted field (with method X) settings get changed to use method Y --> encrypted data gets re-encrypted with the new encryption method
- Encrypted field made unencrypted (checkbox unchecked) --> encrypted data gets stored as plain text
