### PR TITLE
Fix fatal error: Call to undefined method Drupal\Core\Field\BaseField…

### DIFF
--- a/src/FieldEncryptProcessEntities.php
+++ b/src/FieldEncryptProcessEntities.php
@@ -219,8 +219,16 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
    *   Boolean indicating whether to encrypt the field.
    */
   protected function checkField(FieldItemListInterface $field) {
+    if (!is_callable([$field, 'getFieldDefinition'])) {
+      return FALSE;
+    }
+
     /* @var $definition \Drupal\Core\Field\BaseFieldDefinition */
     $definition = $field->getFieldDefinition();
+
+    if (!is_callable([$definition, 'get'])) {
+      return FALSE;
+    }
 
     /* @var $storage \Drupal\Core\Field\FieldConfigStorageBase */
     $storage = $definition->get('fieldStorage');


### PR DESCRIPTION
…Definition::get().
