### PR TITLE
Issue #37 - implement cleaner method for encryption entities

### DIFF
--- a/field_encrypt.module
+++ b/field_encrypt.module
@@ -256,10 +256,8 @@ function field_encrypt_update_field_encryption_finished($success, $results, $ope
  * Encrypts the entity after being saved for the first time.
  */
 function field_encrypt_entity_insert(EntityInterface $entity) {
-  // Save the entity again, but now encrypted.
   if (field_encrypt_allow_encryption($entity)) {
-    $saved_entity = entity_load($entity->getEntityTypeId(), $entity->id());
-    field_encrypt_entity_encrypt($saved_entity);
+    \Drupal::service('field_encrypt.encrypted_field_value_manager')->saveEncryptedFieldValues($entity);
   }
 }
 
@@ -269,32 +267,8 @@ function field_encrypt_entity_insert(EntityInterface $entity) {
  * Encrypts the entity after being updated.
  */
 function field_encrypt_entity_update(EntityInterface $entity) {
-  field_encrypt_entity_encrypt($entity);
-}
-
-/**
- * Encrypt the saved entity.
- *
- * @param \Drupal\Core\Entity\EntityInterface $entity
- *   The entity to encrypt fields on, if appropriate.
- */
-function field_encrypt_entity_encrypt(EntityInterface $entity) {
   if (field_encrypt_allow_encryption($entity)) {
-    // Check if this entity has fields that should be encrypted.
-    $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
-    if (!$field_encrypt_process_entities->entityHasEncryptedFields($entity)) {
-      return;
-    }
-
-    // Set a flag to only perform the encryption once.
-    if ($entity->doFieldEncryption != TRUE) {
-      $entity->doFieldEncryption = TRUE;
-      // Our encryption save action should never trigger a new revision.
-      if ($entity->getEntityType()->hasKey('revision')) {
-        $entity->setNewRevision(FALSE);
-      }
-      $entity->save();
-    }
+    \Drupal::service('field_encrypt.encrypted_field_value_manager')->saveEncryptedFieldValues($entity);
   }
 }
 
@@ -305,12 +279,7 @@ function field_encrypt_entity_encrypt(EntityInterface $entity) {
  */
 function field_encrypt_entity_presave(EntityInterface $entity) {
   if (field_encrypt_allow_encryption($entity)) {
-    // Only encrypt when the correct flag is set.
-    if ($entity->doFieldEncryption == TRUE) {
-      /* @var $field_encrypt_process_entities \Drupal\field_encrypt\FieldEncryptProcessEntities */
-      $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
-      $field_encrypt_process_entities->encryptEntity($entity);
-    }
+    \Drupal::service('field_encrypt.process_entities')->encryptEntity($entity);
   }
 }
 

--- a/src/EncryptedFieldValueManager.php
+++ b/src/EncryptedFieldValueManager.php
@@ -11,6 +11,7 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Query\QueryFactory;
 use Drupal\field_encrypt\Entity\EncryptedFieldValue;
+use Drupal\field_encrypt\Entity\EncryptedFieldValueInterface;
 
 /**
  * Manager containing common functions to manage EncryptedFieldValue entities.
@@ -47,16 +48,22 @@ class EncryptedFieldValueManager implements EncryptedFieldValueManagerInterface 
   /**
    * {@inheritdoc}
    */
-  public function saveEncryptedFieldValue(ContentEntityInterface $entity, $field_name, $delta, $property, $encrypted_value) {
+  public function createEncryptedFieldValue(ContentEntityInterface $entity, $field_name, $delta, $property, $encrypted_value) {
     $langcode = $entity->language()->getId();
     if ($encrypted_field_value = $this->getExistingEntity($entity, $field_name, $delta, $property)) {
-      $translation = $encrypted_field_value->hasTranslation($langcode) ? $encrypted_field_value->getTranslation($langcode) : $encrypted_field_value->addTranslation($langcode);
-      $translation->setEncryptedValue($encrypted_value);
+      // Update an existing encrypted field value, taking into account the
+      // parent entity language.
+      $encrypted_field_value = $encrypted_field_value->hasTranslation($langcode) ? $encrypted_field_value->getTranslation($langcode) : $encrypted_field_value->addTranslation($langcode);
+      $encrypted_field_value->setEncryptedValue($encrypted_value);
+      $encrypted_field_value->save();
     }
     else {
+      // Create a new EncryptedFieldValue entity. The parent entity's (revision)
+      // id might not be known yet, so the EncryptedFieldValue will be saved
+      // by saveEncryptedFieldValues() later on.
       $encrypted_field_value = EncryptedFieldValue::create([
         'entity_type' => $entity->getEntityTypeId(),
-        'entity_id' => $entity->id(),
+        'entity_id' => !$entity->isNew() ? $entity->id() : NULL,
         'entity_revision_id' => $this->getEntityRevisionId($entity),
         'field_name' => $field_name,
         'field_property' => $property,
@@ -64,10 +71,28 @@ class EncryptedFieldValueManager implements EncryptedFieldValueManagerInterface 
         'encrypted_value' => $encrypted_value,
         'langcode' => $langcode,
       ]);
+      $entity->encrypted_field_values[] = $encrypted_field_value;
     }
-    $encrypted_field_value->save();
+    return $encrypted_field_value;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function saveEncryptedFieldValues(ContentEntityInterface $entity) {
+    if (!empty($entity->encrypted_field_values)) {
+      foreach ($entity->encrypted_field_values as $encrypted_field_value) {
+        if ($encrypted_field_value instanceof EncryptedFieldValueInterface) {
+          // Update the parent entity (revision) id, now that it's known.
+          $encrypted_field_value->set('entity_id', $entity->id());
+          $encrypted_field_value->set('entity_revision_id', $this->getEntityRevisionId($entity));
+          // Actually save the EncryptedFieldValue entity.
+          $encrypted_field_value->save();
+        }
+      }
+      unset($entity->encrypted_field_values);
+    }
+  }
 
   /**
    * {@inheritdoc}
@@ -153,6 +178,9 @@ class EncryptedFieldValueManager implements EncryptedFieldValueManagerInterface 
    *   The revision ID.
    */
   protected function getEntityRevisionId(ContentEntityInterface $entity) {
+    if ($entity->isNew()) {
+      return NULL;
+    }
     if ($entity->getEntityType()->hasKey('revision')) {
       $revision_id = $entity->getRevisionId();
     }

--- a/src/EncryptedFieldValueManagerInterface.php
+++ b/src/EncryptedFieldValueManagerInterface.php
@@ -17,7 +17,7 @@ use Drupal\Core\Entity\ContentEntityInterface;
 interface EncryptedFieldValueManagerInterface {
 
   /**
-   * Save an encrypted field value.
+   * Create an encrypted field value, or update an existing one.
    *
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity
    *   The entity to process.
@@ -29,8 +29,19 @@ interface EncryptedFieldValueManagerInterface {
    *   The field property to save.
    * @param string $encrypted_value
    *   The encrypted value to save.
+   *
+   * @return \Drupal\field_encrypt\Entity\EncryptedFieldValueInterface
+   *   The created EncryptedFieldValue entity.
    */
-  public function saveEncryptedFieldValue(ContentEntityInterface $entity, $field_name, $delta, $property, $encrypted_value);
+  public function createEncryptedFieldValue(ContentEntityInterface $entity, $field_name, $delta, $property, $encrypted_value);
+
+  /**
+   * Save encrypted field values and link them to their parent entity.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity to save EncryptedFieldValue entities for.
+   */
+  public function saveEncryptedFieldValues(ContentEntityInterface $entity);
 
   /**
    * Get an encrypted field value.

--- a/src/FieldEncryptProcessEntities.php
+++ b/src/FieldEncryptProcessEntities.php
@@ -275,7 +275,7 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
       // Encrypt property value.
       $processed_value = base64_encode($this->encryptService->encrypt($value, $encryption_profile));
       // Save encrypted value in EncryptedFieldValue entity.
-      $this->encryptedFieldValueManager->saveEncryptedFieldValue($entity, $field->getName(), $delta, $property_name, $processed_value);
+      $this->encryptedFieldValueManager->createEncryptedFieldValue($entity, $field->getName(), $delta, $property_name, $processed_value);
       // Return value to store for unencrypted property.
       // We can't set this to NULL, because then the field values are not saved,
       // so we can't replace them with their unencrypted value on load.
@@ -283,7 +283,7 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
       $context = [
         "entity" => $entity,
         "field" => $field,
-        "property" => $property_name
+        "property" => $property_name,
       ];
       \Drupal::modulehandler()->alter('field_encrypt_unencrypted_storage_value', $unencrypted_storage_value, $context);
       return $unencrypted_storage_value;
@@ -330,10 +330,6 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
         $this->processField($entity, $field, 'decrypt', TRUE, $original_encryption_settings);
       }
     }
-
-    // Set flag to trigger field encryption in field_encrypt_entity_presave().
-    // This will re-encrypt the field with the new settings.
-    $entity->doFieldEncryption = TRUE;
     $entity->save();
 
     // Deactivate encryption if field is no longer encrypted.

--- a/src/Tests/FieldEncryptTest.php
+++ b/src/Tests/FieldEncryptTest.php
@@ -73,10 +73,19 @@ class FieldEncryptTest extends WebTestBase {
   protected $nodeType;
 
   /**
+   * The entity manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityManagerInterface
+   */
+  protected $entityManager;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp() {
     parent::setUp();
+
+    $this->entityManager = $this->container->get('entity.manager');
 
     // Create an admin user.
     $this->adminUser = $this->drupalCreateUser([
@@ -283,6 +292,10 @@ class FieldEncryptTest extends WebTestBase {
     $multi_field->setValue($multi_field_value);
     $test_node->save();
 
+    // Ensure that the node revision has been created.
+    $this->entityManager->getStorage('node')->resetCache(array($test_node->id()));
+    $this->assertNotIdentical($test_node->getRevisionId(), $old_revision_id, 'A new revision has been created.');
+
     // Check existence of EncryptedFieldValue entities.
     $encrypted_field_values = EncryptedFieldValue::loadMultiple();
     $this->assertEqual(10, count($encrypted_field_values));
@@ -337,6 +350,11 @@ class FieldEncryptTest extends WebTestBase {
     ]);
     $test_node->enforceIsNew(TRUE);
     $test_node->save();
+
+    // Reload node after saving.
+    $controller = $this->entityManager->getStorage($test_node->getEntityTypeId());
+    $controller->resetCache(array($test_node->id()));
+    $test_node = $controller->load($test_node->id());
 
     // Add translated values.
     $translated_values = [
@@ -427,7 +445,7 @@ class FieldEncryptTest extends WebTestBase {
     \Drupal::service('content_translation.manager')
       ->setEnabled('node', 'page', TRUE);
     drupal_static_reset();
-    \Drupal::entityManager()->clearCachedDefinitions();
+    $this->entityManager->clearCachedDefinitions();
     \Drupal::service('router.builder')->rebuild();
     \Drupal::service('entity.definition_update_manager')->applyUpdates();
     $this->rebuildContainer();

--- a/tests/src/Unit/FieldEncryptProcessEntitiesTest.php
+++ b/tests/src/Unit/FieldEncryptProcessEntitiesTest.php
@@ -7,6 +7,8 @@
 
 namespace Drupal\Tests\field_encrypt\Unit;
 
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\field_encrypt\FieldEncryptProcessEntities;
 use Drupal\Tests\UnitTestCase;
 
@@ -152,6 +154,13 @@ class FieldEncryptProcessEntitiesTest extends UnitTestCase {
     $this->encryptedFieldValueManager = $this->getMockBuilder('\Drupal\field_encrypt\EncryptedFieldValueManagerInterface')
       ->disableOriginalConstructor()
       ->getMock();
+
+    $container = new ContainerBuilder();
+    $module_handler = $this->getMock(ModuleHandlerInterface::class);
+    $module_handler->expects($this->any())
+      ->method('alter');
+    $container->set('module_handler', $module_handler);
+    \Drupal::setContainer($container);
   }
 
   /**


### PR DESCRIPTION
The reported issue #37 exposed problems with the somewhat clunky way the field_encrypt module was saving the encrypted fields.

The main problem is that entity IDs and / or revision IDs are not known yet in hook_presave(), where the fields get encrypted. Thus the EncryptedFieldValue entities that get created with the encrypted data, cannot be linked to their parent entity at that point.

Initially I solved this by reloading the entity after insert / update, and processing the field encryption then.
However, this caused problems with the workbench_moderation module, enforcing new revisions, even when the field_encrypt module wanted to update the current revision for the encrypted fields, when we don't want to save a new revision.

Long story short, I have found a cleaner and less error-prone way to handle this.
In case the parent entity (revision) IDs are known, we can just save the EncryptedFieldValue entities containing the encrypted data.
In case the parent entity (revision) IDs are not known, we mark the field data as encrypted, and create the accompanying EncryptedFieldValue entities, but not yet saving them - we just attach them to the parent entity object.
When the parent entity object gets passed to hook_entity_insert() or hook_entity_update(), we DO have the proper (revision) IDs, so we set them on the EncryptedFieldValue entities, and save those.

This works with the different tested variations of entities having revisions and / or translations.
It also works with the workbench_moderation module now.
