### PR TITLE
Caching of decrypted data

### DIFF
--- a/config/schema/field_encrypt.schema.yml
+++ b/config/schema/field_encrypt.schema.yml
@@ -14,6 +14,9 @@ field.storage.*.*.third_party.field_encrypt:
     encryption_profile:
       type: string
       label: 'Encryption profile'
+    cache_exclude:
+      type: boolean
+      label: 'Exclude from cache'
 
 field_encrypt.settings:
   type: config_object

--- a/config/schema/field_encrypt.schema.yml
+++ b/config/schema/field_encrypt.schema.yml
@@ -14,7 +14,7 @@ field.storage.*.*.third_party.field_encrypt:
     encryption_profile:
       type: string
       label: 'Encryption profile'
-    cache_exclude:
+    uncacheable:
       type: boolean
       label: 'Exclude from cache'
 

--- a/field_encrypt.module
+++ b/field_encrypt.module
@@ -4,9 +4,12 @@
  * Contains module hooks for field_encrypt.
  */
 
+use Drupal\Core\Entity\ContentEntityTypeInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\DynamicallyFieldableEntityStorageInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\field\Entity\FieldStorageConfig;
 
 /**
  * Implements hook_form_alter().
@@ -88,8 +91,8 @@ function field_encrypt_form_alter(&$form, FormStateInterface $form_state, $form_
       // Add setting to decide if field should be excluded from cache.
       $form['field_encrypt']['field_encrypt']['uncacheable'] = [
         '#type' => 'checkbox',
-        '#title' => t('Exclude from cache'),
-        '#description' => t('Exclude this field from being cached. This will make sure your unencrypted data will not be exposed in the cache, but could have impact on your performance.'),
+        '#title' => t('Uncacheable'),
+        '#description' => t('Mark this field as uncacheable. This will make sure your unencrypted data will not be exposed in the cache, but will have a negative impact on your performance.'),
         '#default_value' => $field->getThirdPartySetting('field_encrypt', 'uncacheable', TRUE),
         '#states' => [
           'visible' => [
@@ -208,20 +211,6 @@ function field_encrypt_entity_delete(EntityInterface $entity) {
 }
 
 /**
- * Implements hook_entity_load().
- */
-function field_encrypt_entity_load(array $entities, $entity_type_id) {
-  /* @var $field_encrypt_process_entities \Drupal\field_encrypt\FieldEncryptProcessEntities */
-  $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
-
-  foreach ($entities as $entity) {
-    if (field_encrypt_allow_encryption($entity)) {
-      $field_encrypt_process_entities->entityCheckPersistentCache($entity);
-    }
-  }
-}
-
-/**
  * Verify if the given entity allows to be encrypted.
  *
  * @param \Drupal\Core\Entity\EntityInterface $entity
@@ -243,4 +232,59 @@ function field_encrypt_allow_encryption(EntityInterface $entity) {
     $allowed = FALSE;
   }
   return $allowed;
+}
+
+/**
+ * Implements hook_entity_type_alter().
+ */
+function field_encrypt_entity_type_alter(array &$entity_types) {
+  $uncacheable_types = field_encrypt_get_uncacheable_entity_types($entity_types);
+  foreach ($uncacheable_types as $uncacheable_type) {
+    $entity_types[$uncacheable_type]->set('static_cache', FALSE);
+    $entity_types[$uncacheable_type]->set('render_cache', FALSE);
+    $entity_types[$uncacheable_type]->set('persistent_cache', FALSE);
+  }
+}
+
+/**
+ * Get a list of uncacheable entity types.
+ *
+ * @param \Drupal\Core\Entity\EntityTypeInterface[] $entity_types
+ *   A list of entity types.
+ * @return array
+ *   List of entity type IDs that are uncacheable.
+ */
+function field_encrypt_get_uncacheable_entity_types($entity_types) {
+  $types = &drupal_static(__FUNCTION__);
+
+  if (is_null($types)) {
+    $types = [];
+    /** @var $entity_types \Drupal\Core\Entity\EntityTypeInterface[] */
+    foreach ($entity_types as $entity_type) {
+      if ($entity_type instanceof ContentEntityTypeInterface) {
+        $storage_class = \Drupal::entityManager()->createHandlerInstance($entity_type->getStorageClass(), $entity_type);
+        if ($storage_class instanceof DynamicallyFieldableEntityStorageInterface) {
+          // Query by filtering on the ID as this is more efficient than filtering
+          // on the entity_type property directly.
+          $ids = \Drupal::entityQuery('field_storage_config')
+            ->condition('id', $entity_type->id() . '.', 'STARTS_WITH')
+            ->execute();
+          // Fetch all fields on entity type.
+          $field_storages = FieldStorageConfig::loadMultiple($ids);
+          if ($field_storages) {
+            foreach ($field_storages as $storage) {
+              // Check if field is encrypted.
+              if ($storage->getThirdPartySetting('field_encrypt', 'uncacheable', FALSE) == TRUE) {
+                // If there is an encrypted field, mark this entity type as
+                // uncacheable.
+                $type = $storage->getTargetEntityTypeId();
+                $types[$type] = $type;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return $types;
 }

--- a/field_encrypt.module
+++ b/field_encrypt.module
@@ -84,6 +84,19 @@ function field_encrypt_form_alter(&$form, FormStateInterface $form_state, $form_
         ],
       );
 
+      // Add setting to decide if field should be excluded from cache.
+      $form['field_encrypt']['field_encrypt']['cache_exclude'] = [
+        '#type' => 'checkbox',
+        '#title' => t('Exclude from cache'),
+        '#description' => t('Exclude this field from being cached. This will make sure your unencrypted data will not be exposed in the cache, but could have impact on your performance.'),
+        '#default_value' => $field->getThirdPartySetting('field_encrypt', 'cache_exclude', TRUE),
+        '#states' => [
+          'visible' => [
+            ':input[name="field_encrypt[encrypt]"]' => array('checked' => TRUE),
+          ],
+        ],
+      ];
+
       // We add functions to process the form when it is saved.
       $form['#entity_builders'][] = 'field_encrypt_form_field_add_form_builder';
     }
@@ -105,7 +118,6 @@ function field_encrypt_form_alter(&$form, FormStateInterface $form_state, $form_
 function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\Entity\FieldStorageConfig $field_storage_config, &$form, \Drupal\Core\Form\FormStateInterface $form_state) {
   $field_encryption_settings = $form_state->getValue('field_encrypt');
   $field_encryption_settings['encrypt'] = (bool) $field_encryption_settings['encrypt'];
-  $original_encryption = $field_storage_config->getThirdPartySettings('field_encrypt');
 
   // If the form has the value, we set it.
   if ($field_encryption_settings['encrypt']) {
@@ -118,6 +130,7 @@ function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\E
     $field_storage_config->unsetThirdPartySetting('field_encrypt', 'encrypt');
     $field_storage_config->unsetThirdPartySetting('field_encrypt', 'properties');
     $field_storage_config->unsetThirdPartySetting('field_encrypt', 'encryption_profile');
+    $field_storage_config->unsetThirdPartySetting('field_encrypt', 'cache_exclude');
   }
 }
 

--- a/field_encrypt.module
+++ b/field_encrypt.module
@@ -86,11 +86,11 @@ function field_encrypt_form_alter(&$form, FormStateInterface $form_state, $form_
       );
 
       // Add setting to decide if field should be excluded from cache.
-      $form['field_encrypt']['field_encrypt']['cache_exclude'] = [
+      $form['field_encrypt']['field_encrypt']['uncacheable'] = [
         '#type' => 'checkbox',
         '#title' => t('Exclude from cache'),
         '#description' => t('Exclude this field from being cached. This will make sure your unencrypted data will not be exposed in the cache, but could have impact on your performance.'),
-        '#default_value' => $field->getThirdPartySetting('field_encrypt', 'cache_exclude', TRUE),
+        '#default_value' => $field->getThirdPartySetting('field_encrypt', 'uncacheable', TRUE),
         '#states' => [
           'visible' => [
             ':input[name="field_encrypt[encrypt]"]' => array('checked' => TRUE),
@@ -131,7 +131,7 @@ function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\E
     $field_storage_config->unsetThirdPartySetting('field_encrypt', 'encrypt');
     $field_storage_config->unsetThirdPartySetting('field_encrypt', 'properties');
     $field_storage_config->unsetThirdPartySetting('field_encrypt', 'encryption_profile');
-    $field_storage_config->unsetThirdPartySetting('field_encrypt', 'cache_exclude');
+    $field_storage_config->unsetThirdPartySetting('field_encrypt', 'uncacheable');
   }
 }
 

--- a/field_encrypt.module
+++ b/field_encrypt.module
@@ -4,6 +4,7 @@
  * Contains module hooks for field_encrypt.
  */
 
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 
@@ -131,6 +132,15 @@ function field_encrypt_form_field_add_form_builder($entity_type, \Drupal\field\E
     $field_storage_config->unsetThirdPartySetting('field_encrypt', 'properties');
     $field_storage_config->unsetThirdPartySetting('field_encrypt', 'encryption_profile');
     $field_storage_config->unsetThirdPartySetting('field_encrypt', 'cache_exclude');
+  }
+}
+
+/**
+ * Implements hook_entity_view().
+ */
+function field_encrypt_entity_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
+  if (field_encrypt_allow_encryption($entity)) {
+    \Drupal::service('field_encrypt.process_entities')->entitySetCacheTags($entity, $build);
   }
 }
 

--- a/field_encrypt.module
+++ b/field_encrypt.module
@@ -238,53 +238,16 @@ function field_encrypt_allow_encryption(EntityInterface $entity) {
  * Implements hook_entity_type_alter().
  */
 function field_encrypt_entity_type_alter(array &$entity_types) {
-  $uncacheable_types = field_encrypt_get_uncacheable_entity_types($entity_types);
-  foreach ($uncacheable_types as $uncacheable_type) {
-    $entity_types[$uncacheable_type]->set('static_cache', FALSE);
-    $entity_types[$uncacheable_type]->set('render_cache', FALSE);
-    $entity_types[$uncacheable_type]->set('persistent_cache', FALSE);
-  }
-}
-
-/**
- * Get a list of uncacheable entity types.
- *
- * @param \Drupal\Core\Entity\EntityTypeInterface[] $entity_types
- *   A list of entity types.
- * @return array
- *   List of entity type IDs that are uncacheable.
- */
-function field_encrypt_get_uncacheable_entity_types($entity_types) {
-  $types = &drupal_static(__FUNCTION__);
-
-  if (is_null($types)) {
-    $types = [];
-    /** @var $entity_types \Drupal\Core\Entity\EntityTypeInterface[] */
-    foreach ($entity_types as $entity_type) {
-      if ($entity_type instanceof ContentEntityTypeInterface) {
-        $storage_class = \Drupal::entityManager()->createHandlerInstance($entity_type->getStorageClass(), $entity_type);
-        if ($storage_class instanceof DynamicallyFieldableEntityStorageInterface) {
-          // Query by filtering on the ID as this is more efficient than filtering
-          // on the entity_type property directly.
-          $ids = \Drupal::entityQuery('field_storage_config')
-            ->condition('id', $entity_type->id() . '.', 'STARTS_WITH')
-            ->execute();
-          // Fetch all fields on entity type.
-          $field_storages = FieldStorageConfig::loadMultiple($ids);
-          if ($field_storages) {
-            foreach ($field_storages as $storage) {
-              // Check if field is encrypted.
-              if ($storage->getThirdPartySetting('field_encrypt', 'uncacheable', FALSE) == TRUE) {
-                // If there is an encrypted field, mark this entity type as
-                // uncacheable.
-                $type = $storage->getTargetEntityTypeId();
-                $types[$type] = $type;
-              }
-            }
-          }
-        }
-      }
+  $uncacheable_types = \Drupal::state()->get('uncacheable_entity_types');
+  if ($uncacheable_types) {
+    // Mark entity types uncacheable if they contain an encrypted field
+    // that has been marked uncacheable.
+    // See Drupal\field_encrypt\EventSubscriber\ConfigSubscriber
+    // setUncacheableEntityTypes().
+    foreach ($uncacheable_types as $uncacheable_type) {
+      $entity_types[$uncacheable_type]->set('static_cache', FALSE);
+      $entity_types[$uncacheable_type]->set('render_cache', FALSE);
+      $entity_types[$uncacheable_type]->set('persistent_cache', FALSE);
     }
   }
-  return $types;
 }

--- a/field_encrypt.module
+++ b/field_encrypt.module
@@ -208,6 +208,20 @@ function field_encrypt_entity_delete(EntityInterface $entity) {
 }
 
 /**
+ * Implements hook_entity_load().
+ */
+function field_encrypt_entity_load(array $entities, $entity_type_id) {
+  /* @var $field_encrypt_process_entities \Drupal\field_encrypt\FieldEncryptProcessEntities */
+  $field_encrypt_process_entities = \Drupal::service('field_encrypt.process_entities');
+
+  foreach ($entities as $entity) {
+    if (field_encrypt_allow_encryption($entity)) {
+      $field_encrypt_process_entities->entityCheckPersistentCache($entity);
+    }
+  }
+}
+
+/**
  * Verify if the given entity allows to be encrypted.
  *
  * @param \Drupal\Core\Entity\EntityInterface $entity

--- a/field_encrypt.services.yml
+++ b/field_encrypt.services.yml
@@ -9,6 +9,6 @@ services:
 
   field_encrypt.config_subscriber:
     class: Drupal\field_encrypt\EventSubscriber\ConfigSubscriber
-    arguments: ['@entity_type.manager', '@entity.query', '@queue', '@string_translation', '@field_encrypt.encrypted_field_value_manager']
+    arguments: ['@entity_type.manager', '@entity.query', '@queue', '@string_translation', '@field_encrypt.encrypted_field_value_manager', '@cache_tags.invalidator']
     tags:
       - { name: event_subscriber }

--- a/field_encrypt.services.yml
+++ b/field_encrypt.services.yml
@@ -9,6 +9,6 @@ services:
 
   field_encrypt.config_subscriber:
     class: Drupal\field_encrypt\EventSubscriber\ConfigSubscriber
-    arguments: ['@entity_type.manager', '@entity.query', '@queue', '@string_translation', '@field_encrypt.encrypted_field_value_manager', '@cache_tags.invalidator']
+    arguments: ['@entity_type.manager', '@entity.query', '@queue', '@string_translation', '@field_encrypt.encrypted_field_value_manager', '@entity.manager', '@state']
     tags:
       - { name: event_subscriber }

--- a/src/EventSubscriber/ConfigSubscriber.php
+++ b/src/EventSubscriber/ConfigSubscriber.php
@@ -173,9 +173,9 @@ class ConfigSubscriber implements EventSubscriberInterface {
     $new_config = $config->get('third_party_settings.field_encrypt');
     $original_config = $config->getOriginal('third_party_settings.field_encrypt');
 
-    // Don't compare 'cache_exclude' setting.
-    unset($new_config['cache_exclude']);
-    unset($original_config['cache_exclude']);
+    // Don't compare 'uncacheable' setting.
+    unset($new_config['uncacheable']);
+    unset($original_config['uncacheable']);
     return $new_config !== $original_config;
   }
 }

--- a/src/FieldEncryptProcessEntities.php
+++ b/src/FieldEncryptProcessEntities.php
@@ -342,8 +342,8 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
    * {@inheritdoc}
    */
   public function entitySetCacheTags(ContentEntityInterface $entity, &$build) {
-    $cache_exclude_fields = $this->getCacheExcludeFields($entity);
-    foreach ($cache_exclude_fields as $field_name) {
+    $uncacheable_fields = $this->getUncacheableFields($entity);
+    foreach ($uncacheable_fields as $field_name) {
       $build[$field_name]['#cache']['max-age'] = 0;
     }
   }
@@ -352,8 +352,8 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
    * {@inheritdoc}
    */
   public function entityCheckPersistentCache(ContentEntityInterface $entity) {
-    $cache_exclude_fields = $this->getCacheExcludeFields($entity);
-    if (!empty($cache_exclude_fields)) {
+    $uncacheable_fields = $this->getUncacheableFields($entity);
+    if (!empty($uncacheable_fields)) {
       // Some fields don't want to be cached, so clear the persistent entity
       // cache, to avoid their values to be cached unencrypted.
       /** @var \Drupal\Core\Entity\ContentEntityStorageInterface $storage */
@@ -371,8 +371,8 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
    * @return array
    *   List of field names that are excluded from cache.
    */
-  protected function getCacheExcludeFields(ContentEntityInterface $entity) {
-    $cache_exclude_fields = [];
+  protected function getUncacheableFields(ContentEntityInterface $entity) {
+    $uncacheable_fields = [];
     foreach ($entity->getFields() as $field) {
       if ($this->checkField($field)) {
         /* @var $definition \Drupal\Core\Field\BaseFieldDefinition */
@@ -380,13 +380,13 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
         /* @var $storage \Drupal\Core\Field\FieldConfigStorageBase */
         $storage = $definition->get('fieldStorage');
 
-        // If cache_exclude is set, set caching max-age to 0.
-        if ($storage->getThirdPartySetting('field_encrypt', 'cache_exclude', TRUE) == TRUE) {
-          $cache_exclude_fields[] = $field->getName();
+        // If uncacheable is set, set caching max-age to 0.
+        if ($storage->getThirdPartySetting('field_encrypt', 'uncacheable', TRUE) == TRUE) {
+          $uncacheable_fields[] = $field->getName();
         }
       }
     }
-    return $cache_exclude_fields;
+    return $uncacheable_fields;
   }
 
 }

--- a/src/FieldEncryptProcessEntities.php
+++ b/src/FieldEncryptProcessEntities.php
@@ -349,20 +349,6 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
   }
 
   /**
-   * {@inheritdoc}
-   */
-  public function entityCheckPersistentCache(ContentEntityInterface $entity) {
-    $uncacheable_fields = $this->getUncacheableFields($entity);
-    if (!empty($uncacheable_fields)) {
-      // Some fields don't want to be cached, so clear the persistent entity
-      // cache, to avoid their values to be cached unencrypted.
-      /** @var \Drupal\Core\Entity\ContentEntityStorageInterface $storage */
-      $storage = $this->entityManager->getStorage($entity->getEntityTypeId());
-      $storage->resetCache([$entity->id()]);
-    }
-  }
-
-  /**
    * Get field names for an entity that are set to be excluded from cache.
    *
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity
@@ -381,7 +367,7 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
         $storage = $definition->get('fieldStorage');
 
         // If uncacheable is set, set caching max-age to 0.
-        if ($storage->getThirdPartySetting('field_encrypt', 'uncacheable', TRUE) == TRUE) {
+        if ($storage->getThirdPartySetting('field_encrypt', 'uncacheable', FALSE) == TRUE) {
           $uncacheable_fields[] = $field->getName();
         }
       }

--- a/src/FieldEncryptProcessEntities.php
+++ b/src/FieldEncryptProcessEntities.php
@@ -338,4 +338,23 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
     }
   }
 
+  /**
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   */
+  public function entitySetCacheTags(ContentEntityInterface $entity, &$build) {
+    foreach ($entity->getFields() as $field) {
+      if ($this->checkField($field)) {
+        /* @var $definition \Drupal\Core\Field\BaseFieldDefinition */
+        $definition = $field->getFieldDefinition();
+        /* @var $storage \Drupal\Core\Field\FieldConfigStorageBase */
+        $storage = $definition->get('fieldStorage');
+
+        // If cache_exclude is set, set caching max-age to 0.
+        if ($storage->getThirdPartySetting('field_encrypt', 'cache_exclude', TRUE) == TRUE) {
+          $build[$field->getName()]['#cache']['max-age'] = 0;
+        }
+      }
+    }
+  }
+
 }

--- a/src/FieldEncryptProcessEntities.php
+++ b/src/FieldEncryptProcessEntities.php
@@ -339,7 +339,7 @@ class FieldEncryptProcessEntities implements FieldEncryptProcessEntitiesInterfac
   }
 
   /**
-   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   * {@inheritdoc}
    */
   public function entitySetCacheTags(ContentEntityInterface $entity, &$build) {
     foreach ($entity->getFields() as $field) {

--- a/src/FieldEncryptProcessEntitiesInterface.php
+++ b/src/FieldEncryptProcessEntitiesInterface.php
@@ -66,4 +66,12 @@ interface FieldEncryptProcessEntitiesInterface {
    */
   public function entitySetCacheTags(ContentEntityInterface $entity, &$build);
 
+  /**
+   * Check if persistent entity cache needs to be reset.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity to check.
+   */
+  public function entityCheckPersistentCache(ContentEntityInterface $entity);
+
 }

--- a/src/FieldEncryptProcessEntitiesInterface.php
+++ b/src/FieldEncryptProcessEntitiesInterface.php
@@ -56,4 +56,14 @@ interface FieldEncryptProcessEntitiesInterface {
    */
   public function updateStoredField($field_name, $field_entity_type, $original_encryption_settings, $entity_id);
 
+  /**
+   * Set the cache tags correctly for each encrypted field on an entity.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity whose fields to set cache tags on.
+   * @param $build
+   *   The entity render array.
+   */
+  public function entitySetCacheTags(ContentEntityInterface $entity, &$build);
+
 }

--- a/src/FieldEncryptProcessEntitiesInterface.php
+++ b/src/FieldEncryptProcessEntitiesInterface.php
@@ -66,12 +66,4 @@ interface FieldEncryptProcessEntitiesInterface {
    */
   public function entitySetCacheTags(ContentEntityInterface $entity, &$build);
 
-  /**
-   * Check if persistent entity cache needs to be reset.
-   *
-   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
-   *   The entity to check.
-   */
-  public function entityCheckPersistentCache(ContentEntityInterface $entity);
-
 }

--- a/src/Tests/FieldEncryptCacheTest.php
+++ b/src/Tests/FieldEncryptCacheTest.php
@@ -61,8 +61,13 @@ class FieldEncryptCacheTest extends FieldEncryptTestBase {
    * Test caching of rendered entity.
    */
   public function testEntityRender() {
+    $render_controller = $this->container->get('entity.manager')->getViewBuilder($this->testNode->getEntityTypeId());
+    $this->verbose(print_r(get_class($render_controller), TRUE));
+
     // Check for max-age = 0 on entity with encrypted field.
     $build = $this->drupalBuildEntityView($this->testNode);
+    // @TODO: this probably doesn't work because hook_entity_view isn't called.
+    // Find out if there's a better way then hook_entity_view to set cache tags.
     $this->assertEqual(0, $build['#cache']['max-age'], 'Cache max-age is set correctly.');
 
     // Set encrypted field as cacheable.

--- a/src/Tests/FieldEncryptCacheTest.php
+++ b/src/Tests/FieldEncryptCacheTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\field_encrypt\Tests\FieldEncryptCacheTest.
+ */
+
+namespace Drupal\field_encrypt\Tests;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\dynamic_page_cache\EventSubscriber\DynamicPageCacheSubscriber;
+
+/**
+ * Tests field encryption caching.
+ *
+ * @group field_encrypt
+ */
+class FieldEncryptCacheTest extends FieldEncryptTestBase {
+
+  /**
+   * Modules to enable for this test.
+   *
+   * @var string[]
+   */
+  public static $modules = ['dynamic_page_cache'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    // Set up fields for encryption.
+    $this->setFieldStorageSettings(TRUE);
+
+    // Create a test entity.
+    $this->createTestNode();
+  }
+
+  /**
+   * Test dynamic page cache.
+   */
+  public function testDynamicPageCache() {
+    // Page should be uncacheable due to max-age = 0.
+    $this->drupalGet('node/' . $this->testNode->id());
+    $this->assertEqual('UNCACHEABLE', $this->drupalGetHeader(DynamicPageCacheSubscriber::HEADER), 'Page with encrypted fields is uncacheable.');
+
+    // Set encrypted field as cacheable.
+    $this->setFieldStorageSettings(TRUE, FALSE, FALSE);
+
+    // Page is cacheable, but currently not cached.
+    $this->drupalGet('node/' . $this->testNode->id());
+    $this->assertEqual('MISS', $this->drupalGetHeader(DynamicPageCacheSubscriber::HEADER), 'Dynamic Page Cache MISS.');
+
+    // Page is cacheable, and should be cached.
+    $this->drupalGet('node/' . $this->testNode->id());
+    $this->assertEqual('HIT', $this->drupalGetHeader(DynamicPageCacheSubscriber::HEADER), 'Dynamic Page Cache HIT.');
+  }
+
+  /**
+   * Test caching of rendered entity.
+   */
+  public function testEntityRender() {
+    // Check for max-age = 0 on entity with encrypted field.
+    $build = $this->drupalBuildEntityView($this->testNode);
+    $this->assertEqual(0, $build['#cache']['max-age'], 'Cache max-age is set correctly.');
+
+    // Set encrypted field as cacheable.
+    $this->setFieldStorageSettings(TRUE, FALSE, FALSE);
+    $build = $this->drupalBuildEntityView($this->testNode);
+    $this->assertEqual(Cache::PERMANENT, $build['#cache']['max-age'], 'Cache max-age is set correctly.');
+  }
+
+}

--- a/src/Tests/FieldEncryptCacheTest.php
+++ b/src/Tests/FieldEncryptCacheTest.php
@@ -89,7 +89,7 @@ class FieldEncryptCacheTest extends FieldEncryptTestBase {
   /**
    * Set up storage settings for test fields.
    */
-  protected function setFieldStorageSettings($encryption = TRUE, $alternate = FALSE, $cache_exclude = TRUE) {
+  protected function setFieldStorageSettings($encryption = TRUE, $alternate = FALSE, $uncacheable = TRUE) {
     $fields = [
       'node.field_test_single' => [
         'properties' => ['value' => 'value', 'summary' => 'summary'],
@@ -107,13 +107,13 @@ class FieldEncryptCacheTest extends FieldEncryptTestBase {
         $field_storage->setThirdPartySetting('field_encrypt', 'encrypt', TRUE);
         $field_storage->setThirdPartySetting('field_encrypt', 'properties', $settings['properties']);
         $field_storage->setThirdPartySetting('field_encrypt', 'encryption_profile', $settings['profile']);
-        $field_storage->setThirdPartySetting('field_encrypt', 'cache_exclude', $cache_exclude);
+        $field_storage->setThirdPartySetting('field_encrypt', 'uncacheable', $uncacheable);
       }
       else {
         $field_storage->unsetThirdPartySetting('field_encrypt', 'encrypt');
         $field_storage->unsetThirdPartySetting('field_encrypt', 'properties');
         $field_storage->unsetThirdPartySetting('field_encrypt', 'encryption_profile');
-        $field_storage->unsetThirdPartySetting('field_encrypt', 'cache_exclude');
+        $field_storage->unsetThirdPartySetting('field_encrypt', 'uncacheable');
       }
       $field_storage->save();
     }

--- a/src/Tests/FieldEncryptCacheTest.php
+++ b/src/Tests/FieldEncryptCacheTest.php
@@ -61,9 +61,6 @@ class FieldEncryptCacheTest extends FieldEncryptTestBase {
    * Test caching of rendered entity.
    */
   public function testEntityRender() {
-    $render_controller = $this->container->get('entity.manager')->getViewBuilder($this->testNode->getEntityTypeId());
-    $this->verbose(print_r(get_class($render_controller), TRUE));
-
     // Check for max-age = 0 on entity with encrypted field.
     $build = $this->drupalBuildEntityView($this->testNode);
     // @TODO: this probably doesn't work because hook_entity_view isn't called.

--- a/src/Tests/FieldEncryptCacheTest.php
+++ b/src/Tests/FieldEncryptCacheTest.php
@@ -62,7 +62,7 @@ class FieldEncryptCacheTest extends FieldEncryptTestBase {
    * Test caching of encrypted fields on entity level.
    */
   public function testEntityCache() {
-    // Check if entity with cache excluded fields is cached by the entity
+    // Check if entity with uncacheable fields is cached by the entity
     // storage.
     $entity_type = $this->testNode->getEntityTypeId();
     $cid = "values:$entity_type:" . $this->testNode->id();

--- a/src/Tests/FieldEncryptTest.php
+++ b/src/Tests/FieldEncryptTest.php
@@ -67,10 +67,10 @@ class FieldEncryptTest extends FieldEncryptTestBase {
     $this->assertText("two");
     $this->assertText("three");
 
-    $result = \Drupal::database()->query("SELECT field_test_single_value FROM {node__field_test_single} WHERE entity_id = :entity_id", array(':entity_id' => $test_node->id()))->fetchField();
+    $result = \Drupal::database()->query("SELECT field_test_single_value FROM {node__field_test_single} WHERE entity_id = :entity_id", array(':entity_id' => $this->testNode->id()))->fetchField();
     $this->assertEqual("[ENCRYPTED]", $result);
 
-    $result = \Drupal::database()->query("SELECT field_test_multi_value FROM {node__field_test_multi} WHERE entity_id = :entity_id", array(':entity_id' => $test_node->id()))->fetchAll();
+    $result = \Drupal::database()->query("SELECT field_test_multi_value FROM {node__field_test_multi} WHERE entity_id = :entity_id", array(':entity_id' => $this->testNode->id()))->fetchAll();
     foreach ($result as $record) {
       $this->assertEqual("[ENCRYPTED]", $record->field_test_multi_value);
     }
@@ -90,17 +90,17 @@ class FieldEncryptTest extends FieldEncryptTestBase {
     $this->assertEqual(5, count($encrypted_field_values));
 
     // Check if text is displayed unencrypted.
-    $this->drupalGet('node/' . $test_node->id());
+    $this->drupalGet('node/' . $this->testNode->id());
     $this->assertText("Lorem ipsum dolor sit amet.");
     $this->assertText("one");
     $this->assertText("two");
     $this->assertText("three");
 
     // Check values saved in the database.
-    $result = \Drupal::database()->query("SELECT field_test_single_value FROM {node__field_test_single} WHERE entity_id = :entity_id", array(':entity_id' => $test_node->id()))->fetchField();
+    $result = \Drupal::database()->query("SELECT field_test_single_value FROM {node__field_test_single} WHERE entity_id = :entity_id", array(':entity_id' => $this->testNode->id()))->fetchField();
     $this->assertEqual("[ENCRYPTED]", $result);
 
-    $result = \Drupal::database()->query("SELECT field_test_multi_value FROM {node__field_test_multi} WHERE entity_id = :entity_id", array(':entity_id' => $test_node->id()))->fetchAll();
+    $result = \Drupal::database()->query("SELECT field_test_multi_value FROM {node__field_test_multi} WHERE entity_id = :entity_id", array(':entity_id' => $this->testNode->id()))->fetchAll();
     foreach ($result as $record) {
       $this->assertEqual("[ENCRYPTED]", $record->field_test_multi_value);
     }
@@ -120,16 +120,16 @@ class FieldEncryptTest extends FieldEncryptTestBase {
     $this->assertEqual(0, count($encrypted_field_values));
 
     // Check if text is displayed unencrypted.
-    $this->drupalGet('node/' . $test_node->id());
+    $this->drupalGet('node/' . $this->testNode->id());
     $this->assertText("Lorem ipsum dolor sit amet.");
     $this->assertText("one");
     $this->assertText("two");
     $this->assertText("three");
 
-    $result = \Drupal::database()->query("SELECT field_test_single_value FROM {node__field_test_single} WHERE entity_id = :entity_id", array(':entity_id' => $test_node->id()))->fetchField();
+    $result = \Drupal::database()->query("SELECT field_test_single_value FROM {node__field_test_single} WHERE entity_id = :entity_id", array(':entity_id' => $this->testNode->id()))->fetchField();
     $this->assertEqual("Lorem ipsum dolor sit amet.", $result);
 
-    $result = \Drupal::database()->query("SELECT field_test_multi_value FROM {node__field_test_multi} WHERE entity_id = :entity_id", array(':entity_id' => $test_node->id()))->fetchAll();
+    $result = \Drupal::database()->query("SELECT field_test_multi_value FROM {node__field_test_multi} WHERE entity_id = :entity_id", array(':entity_id' => $this->testNode->id()))->fetchAll();
     $valid_values = ["one", "two", "three"];
     foreach ($result as $record) {
       $this->assertTrue(in_array($record->field_test_multi_value, $valid_values));
@@ -183,10 +183,10 @@ class FieldEncryptTest extends FieldEncryptTestBase {
     $this->assertText("three");
 
     // Check values saved in the database.
-    $result = \Drupal::database()->query("SELECT field_test_single_value FROM {node_revision__field_test_single} WHERE entity_id = :entity_id", array(':entity_id' => $test_node->id()))->fetchField();
+    $result = \Drupal::database()->query("SELECT field_test_single_value FROM {node_revision__field_test_single} WHERE entity_id = :entity_id", array(':entity_id' => $this->testNode->id()))->fetchField();
     $this->assertEqual("[ENCRYPTED]", $result);
 
-    $result = \Drupal::database()->query("SELECT field_test_multi_value FROM {node_revision__field_test_multi} WHERE entity_id = :entity_id", array(':entity_id' => $test_node->id()))->fetchAll();
+    $result = \Drupal::database()->query("SELECT field_test_multi_value FROM {node_revision__field_test_multi} WHERE entity_id = :entity_id", array(':entity_id' => $this->testNode->id()))->fetchAll();
     foreach ($result as $record) {
       $this->assertEqual("[ENCRYPTED]", $record->field_test_multi_value);
     }
@@ -214,7 +214,7 @@ class FieldEncryptTest extends FieldEncryptTestBase {
     // Reload node after saving.
     $controller = $this->entityManager->getStorage($this->testNode->getEntityTypeId());
     $controller->resetCache(array($this->testNode->id()));
-    $test_node = $controller->load($this->testNode->id());
+    $this->testNode = $controller->load($this->testNode->id());
 
     // Add translated values.
     $translated_values = [
@@ -232,8 +232,8 @@ class FieldEncryptTest extends FieldEncryptTestBase {
         ['value' => "trois"],
       ],
     ];
-    $test_node->addTranslation('fr', $translated_values);
-    $test_node->save();
+    $this->testNode->addTranslation('fr', $translated_values);
+    $this->testNode->save();
 
     // Check existence of EncryptedFieldValue entities.
     $encrypted_field_values = EncryptedFieldValue::loadMultiple();
@@ -247,19 +247,19 @@ class FieldEncryptTest extends FieldEncryptTestBase {
     $this->assertText("three");
 
     // Check if English text is displayed unencrypted.
-    $this->drupalGet('fr/node/' . $test_node->id());
+    $this->drupalGet('fr/node/' . $this->testNode->id());
     $this->assertText("Ceci est un text francais.");
     $this->assertText("un");
     $this->assertText("deux");
     $this->assertText("trois");
 
     // Check values saved in the database.
-    $result = \Drupal::database()->query("SELECT field_test_single_value FROM {node__field_test_single} WHERE entity_id = :entity_id", array(':entity_id' => $test_node->id()))->fetchAll();
+    $result = \Drupal::database()->query("SELECT field_test_single_value FROM {node__field_test_single} WHERE entity_id = :entity_id", array(':entity_id' => $this->testNode->id()))->fetchAll();
     foreach ($result as $record) {
       $this->assertEqual("[ENCRYPTED]", $record->field_test_single_value);
     }
 
-    $result = \Drupal::database()->query("SELECT field_test_multi_value FROM {node__field_test_multi} WHERE entity_id = :entity_id", array(':entity_id' => $test_node->id()))->fetchAll();
+    $result = \Drupal::database()->query("SELECT field_test_multi_value FROM {node__field_test_multi} WHERE entity_id = :entity_id", array(':entity_id' => $this->testNode->id()))->fetchAll();
     foreach ($result as $record) {
       $this->assertEqual("[ENCRYPTED]", $record->field_test_multi_value);
     }

--- a/src/Tests/FieldEncryptTest.php
+++ b/src/Tests/FieldEncryptTest.php
@@ -241,7 +241,7 @@ class FieldEncryptTest extends FieldEncryptTestBase {
 
     // Check if English text is displayed unencrypted.
     $this->drupalGet('node/' . $this->testNode->id());
-    $this->assertText("This is some english text.");
+    $this->assertText("Lorem ipsum dolor sit amet.");
     $this->assertText("one");
     $this->assertText("two");
     $this->assertText("three");

--- a/src/Tests/FieldEncryptTest.php
+++ b/src/Tests/FieldEncryptTest.php
@@ -8,184 +8,20 @@
 namespace Drupal\field_encrypt\Tests;
 
 use Drupal\Core\Field\FieldDefinitionInterface;
-use Drupal\encrypt\Entity\EncryptionProfile;
-use Drupal\field\Entity\FieldConfig;
-use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\field_encrypt\Entity\EncryptedFieldValue;
-use Drupal\key\Entity\Key;
-use Drupal\language\Entity\ConfigurableLanguage;
-use Drupal\node\Entity\Node;
-use Drupal\simpletest\WebTestBase;
-
 
 /**
  * Tests field encryption.
  *
  * @group field_encrypt
  */
-class FieldEncryptTest extends WebTestBase {
-
-  /**
-   * Modules to enable for this test.
-   *
-   * @var string[]
-   */
-  public static $modules = [
-    'node',
-    'field',
-    'field_ui',
-    'text',
-    'locale',
-    'content_translation',
-    'key',
-    'encrypt',
-    'encrypt_test',
-    'field_encrypt',
-  ];
-
-  /**
-   * An administrator user.
-   *
-   * @var \Drupal\user\Entity\User
-   */
-  protected $adminUser;
-
-
-  /**
-   * A list of test keys.
-   *
-   * @var \Drupal\key\Entity\Key[]
-   */
-  protected $keys;
-
-  /**
-   * A list of test encryption profiles.
-   *
-   * @var \Drupal\encrypt\Entity\EncryptionProfile[]
-   */
-  protected $encryptionProfiles;
-
-  /**
-   * The page node type.
-   *
-   * @var \Drupal\node\NodeTypeInterface
-   */
-  protected $nodeType;
-
-  /**
-   * The entity manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityManagerInterface
-   */
-  protected $entityManager;
+class FieldEncryptTest extends FieldEncryptTestBase {
 
   /**
    * {@inheritdoc}
    */
   protected function setUp() {
     parent::setUp();
-
-    $this->entityManager = $this->container->get('entity.manager');
-
-    // Create an admin user.
-    $this->adminUser = $this->drupalCreateUser([
-      'access administration pages',
-      'administer encrypt',
-      'administer keys',
-      'administer field encryption',
-    ], NULL, TRUE);
-    $this->drupalLogin($this->adminUser);
-
-    // Create test keys for encryption.
-    $key_128 = Key::create([
-      'id' => 'key_128',
-      'label' => 'Test Key 128 bit',
-      'key_type' => "encryption",
-      'key_type_settings[key_size]' => '128',
-      'key_provider' => 'config',
-      'key_input_settings[key_value]' => 'mustbesixteenbit',
-    ]);
-    $key_128->save();
-    $this->keys['key_128'] = $key_128;
-
-    $key_256 = Key::create([
-      'id' => 'key_256',
-      'label' => 'Test Key 256 bit',
-      'key_type' => "encryption",
-      'key_type_settings[key_size]' => '256',
-      'key_provider' => 'config',
-      'key_input_settings[key_value]' => 'mustbesixteenbitmustbesixteenbit',
-    ]);
-    $key_256->save();
-    $this->keys['key_256'] = $key_256;
-
-    // Create test encryption profiles.
-    $encryption_profile_1 = EncryptionProfile::create([
-      'id' => 'encryption_profile_1',
-      'label' => 'Encryption profile 1',
-      'encryption_method' => 'test_encryption_method',
-      'encryption_key' => $this->keys['key_128']->id(),
-    ]);
-    $encryption_profile_1->save();
-    $this->encryptionProfiles['encryption_profile_1'] = $encryption_profile_1;
-
-    $encryption_profile_2 = EncryptionProfile::create([
-      'id' => 'encryption_profile_2',
-      'label' => 'Encryption profile 2',
-      'encryption_method' => 'config_test_encryption_method',
-      'encryption_method_configuration[mode]' => 'CFB',
-      'encryption_key' => $this->keys['key_256']->id(),
-    ]);
-    $encryption_profile_2->save();
-    $this->encryptionProfiles['encryption_profile_2'] = $encryption_profile_2;
-
-    // Create content type to test.
-    $this->nodeType = $this->drupalCreateContentType(['type' => 'page', 'name' => 'Basic page']);
-
-    // Create test fields.
-    $single_field_storage = FieldStorageConfig::create(array(
-      'field_name' => 'field_test_single',
-      'entity_type' => 'node',
-      'type' => 'text_with_summary',
-      'cardinality' => 1,
-    ));
-    $single_field_storage->save();
-    $single_field = FieldConfig::create([
-      'field_storage' => $single_field_storage,
-      'bundle' => 'page',
-      'label' => 'Single field',
-    ]);
-    $single_field->save();
-    entity_get_form_display('node', 'page', 'default')
-      ->setComponent('field_test_single')
-      ->save();
-    entity_get_display('node', 'page', 'default')
-      ->setComponent('field_test_single', array(
-        'type' => 'text_default',
-      ))
-      ->save();
-
-    $multi_field_storage = FieldStorageConfig::create(array(
-      'field_name' => 'field_test_multi',
-      'entity_type' => 'node',
-      'type' => 'string',
-      'cardinality' => 3,
-    ));
-    $multi_field_storage->save();
-    $multi_field = FieldConfig::create([
-      'field_storage' => $multi_field_storage,
-      'bundle' => 'page',
-      'label' => 'Multi field',
-    ]);
-    $multi_field->save();
-    entity_get_form_display('node', 'page', 'default')
-      ->setComponent('field_test_multi')
-      ->save();
-    entity_get_display('node', 'page', 'default')
-      ->setComponent('field_test_multi', array(
-        'type' => 'string',
-      ))
-      ->save();
   }
 
   /**
@@ -199,26 +35,9 @@ class FieldEncryptTest extends WebTestBase {
     $this->setFieldStorageSettings(TRUE);
 
     // Save test entity.
-    $test_node = Node::create([
-      'title' => $this->randomMachineName(8),
-      'type' => 'page',
-      'field_test_single' => [
-        [
-          'value' => "Lorem ipsum dolor sit amet.",
-          'summary' => "Lorem ipsum",
-          'format' => filter_default_format(),
-        ],
-      ],
-      'field_test_multi' => [
-        ['value' => "one"],
-        ['value' => "two"],
-        ['value' => "three"],
-      ],
-    ]);
-    $test_node->enforceIsNew(TRUE);
-    $test_node->save();
+    $this->createTestNode();
 
-    $fields = $test_node->getFields();
+    $fields = $this->testNode->getFields();
     // Check field_test_single settings.
     $single_field = $fields['field_test_single'];
     $definition = $single_field->getFieldDefinition();
@@ -242,7 +61,7 @@ class FieldEncryptTest extends WebTestBase {
     $this->assertEqual(5, count($encrypted_field_values));
 
     // Check if text is displayed unencrypted.
-    $this->drupalGet('node/' . $test_node->id());
+    $this->drupalGet('node/' . $this->testNode->id());
     $this->assertText("Lorem ipsum dolor sit amet.");
     $this->assertText("one");
     $this->assertText("two");
@@ -326,55 +145,38 @@ class FieldEncryptTest extends WebTestBase {
     $this->setFieldStorageSettings(TRUE);
 
     // Save test entity.
-    $test_node = Node::create([
-      'title' => $this->randomMachineName(8),
-      'type' => 'page',
-      'field_test_single' => [
-        [
-          'value' => "Lorem ipsum dolor sit amet.",
-          'summary' => "Lorem ipsum",
-          'format' => filter_default_format(),
-        ],
-      ],
-      'field_test_multi' => [
-        ['value' => "one"],
-        ['value' => "two"],
-        ['value' => "three"],
-      ],
-    ]);
-    $test_node->enforceIsNew(TRUE);
-    $test_node->save();
+    $this->createTestNode();
 
     // Create a new revision for the entity.
-    $old_revision_id = $test_node->getRevisionId();
-    $test_node->setNewRevision(TRUE);
-    $test_node->field_test_single->value = "Lorem ipsum dolor sit amet revisioned.";
-    $test_node->field_test_single->summary = "Lorem ipsum revisioned.";
-    $multi_field = $test_node->get('field_test_multi');
+    $old_revision_id = $this->testNode->getRevisionId();
+    $this->testNode->setNewRevision(TRUE);
+    $this->testNode->field_test_single->value = "Lorem ipsum dolor sit amet revisioned.";
+    $this->testNode->field_test_single->summary = "Lorem ipsum revisioned.";
+    $multi_field = $this->testNode->get('field_test_multi');
     $multi_field_value = $multi_field->getValue();
     $multi_field_value[0]['value'] = "four";
     $multi_field_value[1]['value'] = "five";
     $multi_field_value[2]['value'] = "six";
     $multi_field->setValue($multi_field_value);
-    $test_node->save();
+    $this->testNode->save();
 
     // Ensure that the node revision has been created.
-    $this->entityManager->getStorage('node')->resetCache(array($test_node->id()));
-    $this->assertNotIdentical($test_node->getRevisionId(), $old_revision_id, 'A new revision has been created.');
+    $this->entityManager->getStorage('node')->resetCache(array($this->testNode->id()));
+    $this->assertNotIdentical($this->testNode->getRevisionId(), $old_revision_id, 'A new revision has been created.');
 
     // Check existence of EncryptedFieldValue entities.
     $encrypted_field_values = EncryptedFieldValue::loadMultiple();
     $this->assertEqual(10, count($encrypted_field_values));
 
     // Check if revisioned text is displayed unencrypted.
-    $this->drupalGet('node/' . $test_node->id());
+    $this->drupalGet('node/' . $this->testNode->id());
     $this->assertText("Lorem ipsum dolor sit amet revisioned.");
     $this->assertText("four");
     $this->assertText("five");
     $this->assertText("six");
 
     // Check if original text is displayed unencrypted.
-    $this->drupalGet('node/' . $test_node->id() . '/revisions/' . $old_revision_id . '/view');
+    $this->drupalGet('node/' . $this->testNode->id() . '/revisions/' . $old_revision_id . '/view');
     $this->assertText("Lorem ipsum dolor sit amet.");
     $this->assertText("one");
     $this->assertText("two");
@@ -407,30 +209,12 @@ class FieldEncryptTest extends WebTestBase {
     $this->setFieldStorageSettings(TRUE);
 
     // Save test entity.
-    $test_node = Node::create([
-      'title' => $this->randomMachineName(8),
-      'type' => 'page',
-      'field_test_single' => [
-        [
-          'value' => "This is some english text.",
-          'summary' => "English text",
-          'format' => filter_default_format(),
-        ],
-      ],
-      'field_test_multi' => [
-        ['value' => "one"],
-        ['value' => "two"],
-        ['value' => "three"],
-      ],
-      'langcode' => \Drupal::languageManager()->getDefaultLanguage()->getId(),
-    ]);
-    $test_node->enforceIsNew(TRUE);
-    $test_node->save();
+    $this->createTestNode();
 
     // Reload node after saving.
-    $controller = $this->entityManager->getStorage($test_node->getEntityTypeId());
-    $controller->resetCache(array($test_node->id()));
-    $test_node = $controller->load($test_node->id());
+    $controller = $this->entityManager->getStorage($this->testNode->getEntityTypeId());
+    $controller->resetCache(array($this->testNode->id()));
+    $test_node = $controller->load($this->testNode->id());
 
     // Add translated values.
     $translated_values = [
@@ -456,7 +240,7 @@ class FieldEncryptTest extends WebTestBase {
     $this->assertEqual(5, count($encrypted_field_values));
 
     // Check if English text is displayed unencrypted.
-    $this->drupalGet('node/' . $test_node->id());
+    $this->drupalGet('node/' . $this->testNode->id());
     $this->assertText("This is some english text.");
     $this->assertText("one");
     $this->assertText("two");
@@ -479,56 +263,6 @@ class FieldEncryptTest extends WebTestBase {
     foreach ($result as $record) {
       $this->assertEqual("[ENCRYPTED]", $record->field_test_multi_value);
     }
-  }
-
-  /**
-   * Set up storage settings for test fields.
-   */
-  protected function setFieldStorageSettings($encryption = TRUE, $alternate = FALSE) {
-    // Set up storage settings for first field.
-    $this->drupalGet('admin/structure/types/manage/page/fields/node.page.field_test_single/storage');
-    $this->assertFieldByName('field_encrypt[encrypt]', NULL, 'Encrypt field found.');
-    $this->assertFieldByName('field_encrypt[encryption_profile]', NULL, 'Encryption profile field found.');
-
-    $profile_id = ($alternate == TRUE) ? 'encryption_profile_2' : 'encryption_profile_1';
-    $edit = [
-      'field_encrypt[encrypt]' => $encryption,
-      'field_encrypt[properties][value]' => 'value',
-      'field_encrypt[properties][summary]' => 'summary',
-      'field_encrypt[encryption_profile]' => $profile_id,
-    ];
-    $this->drupalPostForm(NULL, $edit, t('Save field settings'));
-    $this->drupalGet('admin/structure/types/manage/page/fields/node.page.field_test_single/storage');
-
-    // Set up storage settings for second field.
-    $this->drupalGet('admin/structure/types/manage/page/fields/node.page.field_test_multi/storage');
-    $this->assertFieldByName('field_encrypt[encrypt]', NULL, 'Encrypt field found.');
-    $this->assertFieldByName('field_encrypt[encryption_profile]', NULL, 'Encryption profile field found.');
-
-    $profile_id = ($alternate == TRUE) ? 'encryption_profile_1' : 'encryption_profile_2';
-    $edit = [
-      'field_encrypt[encrypt]' => $encryption,
-      'field_encrypt[properties][value]' => 'value',
-      'field_encrypt[encryption_profile]' => $profile_id,
-    ];
-    $this->drupalPostForm(NULL, $edit, t('Save field settings'));
-  }
-
-  /**
-   * Set up translation settings for content translation test.
-   */
-  protected function setTranslationSettings() {
-    // Set up extra language.
-    ConfigurableLanguage::createFromLangcode('fr')->save();
-    // Enable translation for the current entity type and ensure the change is
-    // picked up.
-    \Drupal::service('content_translation.manager')
-      ->setEnabled('node', 'page', TRUE);
-    drupal_static_reset();
-    $this->entityManager->clearCachedDefinitions();
-    \Drupal::service('router.builder')->rebuild();
-    \Drupal::service('entity.definition_update_manager')->applyUpdates();
-    $this->rebuildContainer();
   }
 
 }

--- a/src/Tests/FieldEncryptTestBase.php
+++ b/src/Tests/FieldEncryptTestBase.php
@@ -219,7 +219,7 @@ class FieldEncryptTestBase extends WebTestBase {
   /**
    * Set up storage settings for test fields.
    */
-  protected function setFieldStorageSettings($encryption = TRUE, $alternate = FALSE) {
+  protected function setFieldStorageSettings($encryption = TRUE, $alternate = FALSE, $cache_exclude = TRUE) {
     // Set up storage settings for first field.
     $this->drupalGet('admin/structure/types/manage/page/fields/node.page.field_test_single/storage');
     $this->assertFieldByName('field_encrypt[encrypt]', NULL, 'Encrypt field found.');
@@ -231,7 +231,7 @@ class FieldEncryptTestBase extends WebTestBase {
       'field_encrypt[properties][value]' => 'value',
       'field_encrypt[properties][summary]' => 'summary',
       'field_encrypt[encryption_profile]' => $profile_id,
-      'field_encrypt[cache_exclude]' => 1,
+      'field_encrypt[cache_exclude]' => $cache_exclude,
     ];
     $this->drupalPostForm(NULL, $edit, t('Save field settings'));
     $this->drupalGet('admin/structure/types/manage/page/fields/node.page.field_test_single/storage');
@@ -246,7 +246,7 @@ class FieldEncryptTestBase extends WebTestBase {
       'field_encrypt[encrypt]' => $encryption,
       'field_encrypt[properties][value]' => 'value',
       'field_encrypt[encryption_profile]' => $profile_id,
-      'field_encrypt[cache_exclude]' => 1,
+      'field_encrypt[cache_exclude]' => $cache_exclude,
     ];
     $this->drupalPostForm(NULL, $edit, t('Save field settings'));
   }

--- a/src/Tests/FieldEncryptTestBase.php
+++ b/src/Tests/FieldEncryptTestBase.php
@@ -20,7 +20,7 @@ use Drupal\simpletest\WebTestBase;
  *
  * @group field_encrypt
  */
-class FieldEncryptTestBase extends WebTestBase {
+abstract class FieldEncryptTestBase extends WebTestBase {
 
   /**
    * Modules to enable for this test.

--- a/src/Tests/FieldEncryptTestBase.php
+++ b/src/Tests/FieldEncryptTestBase.php
@@ -1,0 +1,271 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\field_encrypt\Tests\FieldEncryptTestBase.
+ */
+
+namespace Drupal\field_encrypt\Tests;
+
+use Drupal\encrypt\Entity\EncryptionProfile;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\key\Entity\Key;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\node\Entity\Node;
+use Drupal\simpletest\WebTestBase;
+
+/**
+ * Base test class for field_encrypt.
+ *
+ * @group field_encrypt
+ */
+class FieldEncryptTestBase extends WebTestBase {
+
+  /**
+   * Modules to enable for this test.
+   *
+   * @var string[]
+   */
+  public static $modules = [
+    'node',
+    'field',
+    'field_ui',
+    'text',
+    'locale',
+    'content_translation',
+    'key',
+    'encrypt',
+    'encrypt_test',
+    'field_encrypt',
+  ];
+
+  /**
+   * An administrator user.
+   *
+   * @var \Drupal\user\Entity\User
+   */
+  protected $adminUser;
+
+
+  /**
+   * A list of test keys.
+   *
+   * @var \Drupal\key\Entity\Key[]
+   */
+  protected $keys;
+
+  /**
+   * A list of test encryption profiles.
+   *
+   * @var \Drupal\encrypt\Entity\EncryptionProfile[]
+   */
+  protected $encryptionProfiles;
+
+  /**
+   * The page node type.
+   *
+   * @var \Drupal\node\NodeTypeInterface
+   */
+  protected $nodeType;
+
+  /**
+   * The entity manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityManagerInterface
+   */
+  protected $entityManager;
+
+  /**
+   * A test node.
+   *
+   * @var \Drupal\node\Entity\Node $testNode
+   */
+  protected $testNode;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->entityManager = $this->container->get('entity.manager');
+
+    // Create an admin user.
+    $this->adminUser = $this->drupalCreateUser([
+      'access administration pages',
+      'administer encrypt',
+      'administer keys',
+      'administer field encryption',
+    ], NULL, TRUE);
+    $this->drupalLogin($this->adminUser);
+
+    // Create test keys for encryption.
+    $key_128 = Key::create([
+      'id' => 'key_128',
+      'label' => 'Test Key 128 bit',
+      'key_type' => "encryption",
+      'key_type_settings[key_size]' => '128',
+      'key_provider' => 'config',
+      'key_input_settings[key_value]' => 'mustbesixteenbit',
+    ]);
+    $key_128->save();
+    $this->keys['key_128'] = $key_128;
+
+    $key_256 = Key::create([
+      'id' => 'key_256',
+      'label' => 'Test Key 256 bit',
+      'key_type' => "encryption",
+      'key_type_settings[key_size]' => '256',
+      'key_provider' => 'config',
+      'key_input_settings[key_value]' => 'mustbesixteenbitmustbesixteenbit',
+    ]);
+    $key_256->save();
+    $this->keys['key_256'] = $key_256;
+
+    // Create test encryption profiles.
+    $encryption_profile_1 = EncryptionProfile::create([
+      'id' => 'encryption_profile_1',
+      'label' => 'Encryption profile 1',
+      'encryption_method' => 'test_encryption_method',
+      'encryption_key' => $this->keys['key_128']->id(),
+    ]);
+    $encryption_profile_1->save();
+    $this->encryptionProfiles['encryption_profile_1'] = $encryption_profile_1;
+
+    $encryption_profile_2 = EncryptionProfile::create([
+      'id' => 'encryption_profile_2',
+      'label' => 'Encryption profile 2',
+      'encryption_method' => 'config_test_encryption_method',
+      'encryption_method_configuration[mode]' => 'CFB',
+      'encryption_key' => $this->keys['key_256']->id(),
+    ]);
+    $encryption_profile_2->save();
+    $this->encryptionProfiles['encryption_profile_2'] = $encryption_profile_2;
+
+    // Create content type to test.
+    $this->nodeType = $this->drupalCreateContentType(['type' => 'page', 'name' => 'Basic page']);
+
+    // Create test fields.
+    $single_field_storage = FieldStorageConfig::create(array(
+      'field_name' => 'field_test_single',
+      'entity_type' => 'node',
+      'type' => 'text_with_summary',
+      'cardinality' => 1,
+    ));
+    $single_field_storage->save();
+    $single_field = FieldConfig::create([
+      'field_storage' => $single_field_storage,
+      'bundle' => 'page',
+      'label' => 'Single field',
+    ]);
+    $single_field->save();
+    entity_get_form_display('node', 'page', 'default')
+      ->setComponent('field_test_single')
+      ->save();
+    entity_get_display('node', 'page', 'default')
+      ->setComponent('field_test_single', array(
+        'type' => 'text_default',
+      ))
+      ->save();
+
+    $multi_field_storage = FieldStorageConfig::create(array(
+      'field_name' => 'field_test_multi',
+      'entity_type' => 'node',
+      'type' => 'string',
+      'cardinality' => 3,
+    ));
+    $multi_field_storage->save();
+    $multi_field = FieldConfig::create([
+      'field_storage' => $multi_field_storage,
+      'bundle' => 'page',
+      'label' => 'Multi field',
+    ]);
+    $multi_field->save();
+    entity_get_form_display('node', 'page', 'default')
+      ->setComponent('field_test_multi')
+      ->save();
+    entity_get_display('node', 'page', 'default')
+      ->setComponent('field_test_multi', array(
+        'type' => 'string',
+      ))
+      ->save();
+  }
+
+  /**
+   * Creates a test node.
+   */
+  protected function createTestNode() {
+    $this->testNode = Node::create([
+      'title' => $this->randomMachineName(8),
+      'type' => 'page',
+      'field_test_single' => [
+        [
+          'value' => "Lorem ipsum dolor sit amet.",
+          'summary' => "Lorem ipsum",
+          'format' => filter_default_format(),
+        ],
+      ],
+      'field_test_multi' => [
+        ['value' => "one"],
+        ['value' => "two"],
+        ['value' => "three"],
+      ],
+    ]);
+    $this->testNode->enforceIsNew(TRUE);
+    $this->testNode->save();
+  }
+
+  /**
+   * Set up storage settings for test fields.
+   */
+  protected function setFieldStorageSettings($encryption = TRUE, $alternate = FALSE) {
+    // Set up storage settings for first field.
+    $this->drupalGet('admin/structure/types/manage/page/fields/node.page.field_test_single/storage');
+    $this->assertFieldByName('field_encrypt[encrypt]', NULL, 'Encrypt field found.');
+    $this->assertFieldByName('field_encrypt[encryption_profile]', NULL, 'Encryption profile field found.');
+
+    $profile_id = ($alternate == TRUE) ? 'encryption_profile_2' : 'encryption_profile_1';
+    $edit = [
+      'field_encrypt[encrypt]' => $encryption,
+      'field_encrypt[properties][value]' => 'value',
+      'field_encrypt[properties][summary]' => 'summary',
+      'field_encrypt[encryption_profile]' => $profile_id,
+      'field_encrypt[cache_exclude]' => 1,
+    ];
+    $this->drupalPostForm(NULL, $edit, t('Save field settings'));
+    $this->drupalGet('admin/structure/types/manage/page/fields/node.page.field_test_single/storage');
+
+    // Set up storage settings for second field.
+    $this->drupalGet('admin/structure/types/manage/page/fields/node.page.field_test_multi/storage');
+    $this->assertFieldByName('field_encrypt[encrypt]', NULL, 'Encrypt field found.');
+    $this->assertFieldByName('field_encrypt[encryption_profile]', NULL, 'Encryption profile field found.');
+
+    $profile_id = ($alternate == TRUE) ? 'encryption_profile_1' : 'encryption_profile_2';
+    $edit = [
+      'field_encrypt[encrypt]' => $encryption,
+      'field_encrypt[properties][value]' => 'value',
+      'field_encrypt[encryption_profile]' => $profile_id,
+      'field_encrypt[cache_exclude]' => 1,
+    ];
+    $this->drupalPostForm(NULL, $edit, t('Save field settings'));
+  }
+
+  /**
+   * Set up translation settings for content translation test.
+   */
+  protected function setTranslationSettings() {
+    // Set up extra language.
+    ConfigurableLanguage::createFromLangcode('fr')->save();
+    // Enable translation for the current entity type and ensure the change is
+    // picked up.
+    \Drupal::service('content_translation.manager')
+      ->setEnabled('node', 'page', TRUE);
+    drupal_static_reset();
+    $this->entityManager->clearCachedDefinitions();
+    \Drupal::service('router.builder')->rebuild();
+    \Drupal::service('entity.definition_update_manager')->applyUpdates();
+    $this->rebuildContainer();
+  }
+
+}

--- a/src/Tests/FieldEncryptTestBase.php
+++ b/src/Tests/FieldEncryptTestBase.php
@@ -53,7 +53,7 @@ abstract class FieldEncryptTestBase extends WebTestBase {
    *
    * @var \Drupal\key\Entity\Key[]
    */
-  protected $keys;
+  protected $testKeys;
 
   /**
    * A list of test encryption profiles.
@@ -85,6 +85,8 @@ abstract class FieldEncryptTestBase extends WebTestBase {
 
   /**
    * {@inheritdoc}
+   *
+   * @TODO: Simplify setUp() by extending EncryptTestBase when https://www.drupal.org/node/2692387 lands.
    */
   protected function setUp() {
     parent::setUp();
@@ -102,33 +104,33 @@ abstract class FieldEncryptTestBase extends WebTestBase {
 
     // Create test keys for encryption.
     $key_128 = Key::create([
-      'id' => 'key_128',
+      'id' => 'testing_key_128',
       'label' => 'Test Key 128 bit',
       'key_type' => "encryption",
-      'key_type_settings[key_size]' => '128',
+      'key_type_settings' => ['key_size' => '128'],
       'key_provider' => 'config',
-      'key_input_settings[key_value]' => 'mustbesixteenbit',
+      'key_provider_settings' => ['key_value' => 'mustbesixteenbit'],
     ]);
     $key_128->save();
-    $this->keys['key_128'] = $key_128;
+    $this->testKeys['testing_key_128'] = $key_128;
 
     $key_256 = Key::create([
-      'id' => 'key_256',
+      'id' => 'testing_key_256',
       'label' => 'Test Key 256 bit',
       'key_type' => "encryption",
-      'key_type_settings[key_size]' => '256',
+      'key_type_settings' => ['key_size' => '256'],
       'key_provider' => 'config',
-      'key_input_settings[key_value]' => 'mustbesixteenbitmustbesixteenbit',
+      'key_provider_settings' => ['key_value' => 'mustbesixteenbitmustbesixteenbit'],
     ]);
     $key_256->save();
-    $this->keys['key_256'] = $key_256;
+    $this->testKeys['testing_key_256'] = $key_256;
 
     // Create test encryption profiles.
     $encryption_profile_1 = EncryptionProfile::create([
       'id' => 'encryption_profile_1',
       'label' => 'Encryption profile 1',
       'encryption_method' => 'test_encryption_method',
-      'encryption_key' => $this->keys['key_128']->id(),
+      'encryption_key' => $this->testKeys['testing_key_128']->id(),
     ]);
     $encryption_profile_1->save();
     $this->encryptionProfiles['encryption_profile_1'] = $encryption_profile_1;
@@ -137,8 +139,8 @@ abstract class FieldEncryptTestBase extends WebTestBase {
       'id' => 'encryption_profile_2',
       'label' => 'Encryption profile 2',
       'encryption_method' => 'config_test_encryption_method',
-      'encryption_method_configuration[mode]' => 'CFB',
-      'encryption_key' => $this->keys['key_256']->id(),
+      'encryption_method_configuration' => ['mode' => 'CFB'],
+      'encryption_key' => $this->testKeys['testing_key_256']->id(),
     ]);
     $encryption_profile_2->save();
     $this->encryptionProfiles['encryption_profile_2'] = $encryption_profile_2;

--- a/src/Tests/FieldEncryptTestBase.php
+++ b/src/Tests/FieldEncryptTestBase.php
@@ -221,7 +221,7 @@ abstract class FieldEncryptTestBase extends WebTestBase {
   /**
    * Set up storage settings for test fields.
    */
-  protected function setFieldStorageSettings($encryption = TRUE, $alternate = FALSE, $cache_exclude = TRUE) {
+  protected function setFieldStorageSettings($encryption = TRUE, $alternate = FALSE, $uncacheable = TRUE) {
     // Set up storage settings for first field.
     $this->drupalGet('admin/structure/types/manage/page/fields/node.page.field_test_single/storage');
     $this->assertFieldByName('field_encrypt[encrypt]', NULL, 'Encrypt field found.');
@@ -233,7 +233,7 @@ abstract class FieldEncryptTestBase extends WebTestBase {
       'field_encrypt[properties][value]' => 'value',
       'field_encrypt[properties][summary]' => 'summary',
       'field_encrypt[encryption_profile]' => $profile_id,
-      'field_encrypt[cache_exclude]' => $cache_exclude,
+      'field_encrypt[uncacheable]' => $uncacheable,
     ];
     $this->drupalPostForm(NULL, $edit, t('Save field settings'));
     $this->drupalGet('admin/structure/types/manage/page/fields/node.page.field_test_single/storage');
@@ -248,7 +248,7 @@ abstract class FieldEncryptTestBase extends WebTestBase {
       'field_encrypt[encrypt]' => $encryption,
       'field_encrypt[properties][value]' => 'value',
       'field_encrypt[encryption_profile]' => $profile_id,
-      'field_encrypt[cache_exclude]' => $cache_exclude,
+      'field_encrypt[uncacheable]' => $uncacheable,
     ];
     $this->drupalPostForm(NULL, $edit, t('Save field settings'));
   }


### PR DESCRIPTION
First draft to tackle the caching of encrypted data issue (see https://github.com/d8-contrib-modules/field_encrypt/issues/17).

This PR:
- adds a setting to the field storage field_encrypt settings to decide whether this particular encrypted field should be excluded from (render) caching.
- adds a first attempt at defining tests to test the cacheability of the encrypted data.
- implements hook_entity_view to set the cache max-age setting to 0 conditionally.
