### PR TITLE
Add hook_field_encrypt_allow_encryption

### DIFF
--- a/field_encrypt.api.php
+++ b/field_encrypt.api.php
@@ -4,6 +4,8 @@
  * Hooks for Field Encrypt module.
  */
 
+use Drupal\Core\Entity\ContentEntityInterface;
+
 /**
  * Hook to alter values that will be stored in the unencrypted field storage.
  *
@@ -35,6 +37,41 @@ function hook_field_encrypt_unencrypted_storage_value_alter(&$unencrypted_storag
       if ($property == "summary") {
         $unencrypted_storage_value = "[ENCRYPTED SUMMARY]";
       }
+    }
+  }
+}
+
+/**
+ * Hook to specify if a field property on a given entity should be encrypted.
+ *
+ * Allows other modules to specify whether a specific field property should
+ * not be encrypted by field_encrypt module, regardless of the field encryption
+ * settings set in the field storage configuration.
+ *
+ * If conditions are met where a field property should not be encrypted, return
+ * FALSE in your hook implementation.
+ *
+ * Note: this only stops the encryption of a field that was set up to be
+ * encrypted. It does not allow a field without field encryption settings to be
+ * encrypted, because there are no settings defined to do so.
+ *
+ * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+ *   The entity to encrypt fields on.
+ * @param string $field_name
+ *   The field name to update.
+ * @param string $delta
+ *   The field delta.
+ * @param string $property_name
+ *   The field property name.
+ *
+ * @return bool
+ *   Return FALSE if field property should not be encrypted.
+ */
+function hook_field_encrypt_allow_encryption(\Drupal\Core\Entity\ContentEntityInterface $entity, $field_name, $delta, $property_name) {
+  // Only encrypt fields on unpublished nodes.
+  if ($entity instanceof \Drupal\node\Entity\Node) {
+    if ($entity->isPublished()) {
+      return FALSE;
     }
   }
 }

--- a/src/EncryptedFieldValueManager.php
+++ b/src/EncryptedFieldValueManager.php
@@ -110,21 +110,9 @@ class EncryptedFieldValueManager implements EncryptedFieldValueManagerInterface 
   }
 
   /**
-   * Loads an existing EncryptedFieldValue entity.
-   *
-   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
-   *   The entity to check.
-   * @param string $field_name
-   *   The field name to check.
-   * @param int $delta
-   *   The field delta to check.
-   * @param string $property
-   *   The field property to check.
-   *
-   * @return bool|\Drupal\field_encrypt\Entity\EncryptedFieldValue
-   *   The existing EncryptedFieldValue entity.
+   * {@inheritdoc}
    */
-  protected function getExistingEntity(ContentEntityInterface $entity, $field_name, $delta, $property) {
+  public function getExistingEntity(ContentEntityInterface $entity, $field_name, $delta, $property) {
     $query = $this->entityQuery->get('encrypted_field_value')
       ->condition('entity_type', $entity->getEntityTypeId())
       ->condition('entity_id', $entity->id())

--- a/src/EncryptedFieldValueManagerInterface.php
+++ b/src/EncryptedFieldValueManagerInterface.php
@@ -61,6 +61,23 @@ interface EncryptedFieldValueManagerInterface {
   public function getEncryptedFieldValue(ContentEntityInterface $entity, $field_name, $delta, $property);
 
   /**
+   * Loads an existing EncryptedFieldValue entity.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity to check.
+   * @param string $field_name
+   *   The field name to check.
+   * @param int $delta
+   *   The field delta to check.
+   * @param string $property
+   *   The field property to check.
+   *
+   * @return bool|\Drupal\field_encrypt\Entity\EncryptedFieldValue
+   *   The existing EncryptedFieldValue entity.
+   */
+  public function getExistingEntity(ContentEntityInterface $entity, $field_name, $delta, $property);
+
+  /**
    * Delete encrypted field values on a given entity.
    *
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity

--- a/tests/src/Unit/FieldEncryptProcessEntitiesTest.php
+++ b/tests/src/Unit/FieldEncryptProcessEntitiesTest.php
@@ -300,7 +300,7 @@ class FieldEncryptProcessEntitiesTest extends UnitTestCase {
 
     // Set up a mock for the EncryptionProfile class to mock some methods.
     $service = $this->getMockBuilder('\Drupal\field_encrypt\FieldEncryptProcessEntities')
-      ->setMethods(['checkField'])
+      ->setMethods(['checkField', 'allowEncryption'])
       ->setConstructorArgs(array(
         $this->queryFactory,
         $this->entityManager,
@@ -314,6 +314,9 @@ class FieldEncryptProcessEntitiesTest extends UnitTestCase {
     // scope of this specific unit test.
     $service->expects($this->once())
       ->method('checkField')
+      ->will($this->returnValue(TRUE));
+    $service->expects($this->any())
+      ->method('allowEncryption')
       ->will($this->returnValue(TRUE));
 
     $service->encryptEntity($this->entity);
@@ -381,7 +384,7 @@ class FieldEncryptProcessEntitiesTest extends UnitTestCase {
 
     // Set up a mock for the EncryptionProfile class to mock some methods.
     $service = $this->getMockBuilder('\Drupal\field_encrypt\FieldEncryptProcessEntities')
-      ->setMethods(['checkField', 'processField'])
+      ->setMethods(['checkField', 'processField', 'allowEncryption'])
       ->setConstructorArgs(array(
         $this->queryFactory,
         $this->entityManager,
@@ -399,6 +402,13 @@ class FieldEncryptProcessEntitiesTest extends UnitTestCase {
       $service->expects($this->never())
         ->method('processField');
     }
+
+    $service->expects($this->any())
+      ->method('checkField')
+      ->will($this->returnValue(TRUE));
+    $service->expects($this->any())
+      ->method('allowEncryption')
+      ->will($this->returnValue(TRUE));
 
     $service->updateStoredField($field_name, $field_entity_type, $original_encryption_settings, $entity_id);
   }


### PR DESCRIPTION
See https://github.com/d8-contrib-modules/field_encrypt/issues/47 for details.

This PR introduces a new hook that can be implemented, to allow other modules to stop the encryption of a field property, based on conditions they can set.
This allows for the use case laid out in https://github.com/d8-contrib-modules/field_encrypt/issues/47 by @arknoll.
