### PR TITLE
Add overview page with encrypted fields and a "Decrypt" operation link.

### DIFF
--- a/field_encrypt.links.task.yml
+++ b/field_encrypt.links.task.yml
@@ -3,6 +3,11 @@ field_encrypt.settings_tab:
   title: Settings
   base_route: field_encrypt.settings
 
+field_encrypt.field_overview_tab:
+  route_name: field_encrypt.field_overview
+  title: Encrypted fields overview
+  base_route: field_encrypt.settings
+
 field_encrypt.field_update_tab:
   route_name: field_encrypt.field_update
   title: Update fields

--- a/field_encrypt.routing.yml
+++ b/field_encrypt.routing.yml
@@ -13,3 +13,17 @@ field_encrypt.field_update:
     _title: 'Update fields'
   requirements:
     _permission: 'administer field encryption'
+
+field_encrypt.field_overview:
+  path: '/admin/config/system/field-encrypt/field-overview'
+  defaults:
+    _controller: '\Drupal\field_encrypt\Controller\FieldOverviewController::overview'
+  requirements:
+    _permission: 'administer field encryption'
+
+field_encrypt.field_decrypt_confirm:
+  path: '/admin/config/system/field-encrypt/field-decrypt/{entity_type}/{field_name}'
+  defaults:
+    _form: 'Drupal\field_encrypt\Form\FieldEncryptDecryptForm'
+  requirements:
+    _permission: 'administer field encryption'

--- a/src/Controller/FieldOverviewController.php
+++ b/src/Controller/FieldOverviewController.php
@@ -1,0 +1,148 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\field_encrypt\Controller\FieldOverviewController.
+ */
+
+namespace Drupal\field_encrypt\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Query\QueryFactory;
+use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Renders encrypted fields overview.
+ */
+class FieldOverviewController extends ControllerBase {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The entity query service.
+   *
+   * @var \Drupal\Core\Entity\Query\QueryFactory
+   */
+  protected $entityQuery;
+
+  /**
+   * Creates a new FieldOverviewController object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   * @param \Drupal\Core\Entity\Query\QueryFactory $entity_query
+   *   The entity query service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, QueryFactory $entity_query) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityQuery = $entity_query;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('entity.query')
+    );
+  }
+
+  /**
+   * Renders overview page of encrypted fields.
+   */
+  public function overview() {
+    $encrypted_fields = $this->getEncryptedFields();
+    $build['table'] = array(
+      '#type' => 'table',
+      '#header' => [
+        'field_name' => $this->t('Field'),
+        'entity_type' => $this->t('Entity type'),
+        'properties' => $this->t('Properties'),
+        'encryption_profile' => $this->t('Encryption profile'),
+        'count' => $this->t('# encrypted field values'),
+        'operations' => $this->t('Operations'),
+      ],
+      '#title' => 'Overview of encrypted fields',
+      '#rows' => array(),
+      '#empty' => $this->t('There are no encrypted fields.'),
+    );
+
+    foreach ($encrypted_fields as $encrypted_field) {
+      $properties = $encrypted_field->getThirdPartySetting('field_encrypt', 'properties', []);
+      $entity_type = $encrypted_field->getTargetEntityTypeId();
+      $field_name = $encrypted_field->getName();
+
+      $row = [
+        'field_name' => $field_name,
+        'entity_type' => $entity_type,
+        'properties' => [
+          'data' => [
+            '#theme' => 'item_list',
+            '#items' => array_filter($properties),
+          ],
+        ],
+        'encryption_profile' => $encrypted_field->getThirdPartySetting('field_encrypt', 'encryption_profile', ''),
+        'count' => $this->getEncryptedFieldValueCount($entity_type, $field_name),
+        'operations' => [
+          'data' => [
+            '#type' => 'operations',
+            '#links' => [
+              'decrypt' => [
+                'title' => $this->t('Decrypt'),
+                'url' => Url::fromRoute('field_encrypt.field_decrypt_confirm', ['entity_type' => $entity_type, 'field_name' => $field_name]),
+              ],
+            ],
+          ],
+        ],
+      ];
+      $build['table']['#rows'][$encrypted_field->id()] = $row;
+    }
+    return $build;
+  }
+
+  /**
+   * Get a list of encrypted fields' storage entities.
+   *
+   * @return \Drupal\field\FieldStorageConfigInterface[]
+   *   An array of FieldStorageConfig entities for encrypted fields.
+   */
+  protected function getEncryptedFields() {
+    $encrypted_fields = [];
+    $storage = $this->entityTypeManager->getStorage('field_storage_config');
+    $fields = $storage->loadMultiple();
+    foreach ($fields as $field) {
+      if ($field->getThirdPartySetting('field_encrypt', 'encrypt', FALSE) == TRUE) {
+        $encrypted_fields[] = $field;
+      }
+    }
+    return $encrypted_fields;
+  }
+
+  /**
+   * Get the number of encrypted field values for a given field on entity type.
+   *
+   * @param string $entity_type
+   *   The entity type to check.
+   * @param string $field_name
+   *   The field name to check.
+   *
+   * @return int
+   *   The number of encrypted field values.
+   */
+  protected function getEncryptedFieldValueCount($entity_type, $field_name) {
+    $query = $this->entityQuery->get('encrypted_field_value')
+      ->condition('entity_type', $entity_type)
+      ->condition('field_name', $field_name);
+    $values = $query->execute();
+    return count($values);
+  }
+
+}

--- a/src/Form/FieldEncryptDecryptForm.php
+++ b/src/Form/FieldEncryptDecryptForm.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\field_encrypt\Form\FieldEncryptDecryptForm.
+ */
+
+namespace Drupal\field_encrypt\Form;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\ConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Confirmation form for removing encryption on field.
+ */
+class FieldEncryptDecryptForm extends ConfirmFormBase {
+
+  /**
+   * The entity type.
+   *
+   * @var string
+   */
+  protected $entityType;
+
+  /**
+   * The field name to decrypt.
+   *
+   * @var string
+   */
+  protected $fieldName;
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a new FieldEncryptDecryptForm.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'field_encrypt_decrypt_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return t('Are you sure you want to remove encryption for field %field on %entity_type?', array('%field' => $this->fieldName, '%entity_type' => $this->entityType));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return new Url('field_encrypt.field_overview');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfirmText() {
+    return t('Remove field encryption');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDescription() {
+    return t('This action removes field encryption from the specified field. Existing field data will be decrypted through a batch process.');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, $entity_type = NULL, $field_name = NULL) {
+    $this->entityType = $entity_type;
+    $this->fieldName = $field_name;
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $storage = $this->entityTypeManager->getStorage('field_storage_config');
+    $field_storage_config = $storage->load($this->entityType . '.' . $this->fieldName);
+    $field_storage_config->unsetThirdPartySetting('field_encrypt', 'encrypt');
+    $field_storage_config->unsetThirdPartySetting('field_encrypt', 'properties');
+    $field_storage_config->unsetThirdPartySetting('field_encrypt', 'encryption_profile');
+    $field_storage_config->save();
+    $form_state->setRedirectUrl($this->getCancelUrl());
+  }
+
+}


### PR DESCRIPTION
Followup for https://github.com/d8-contrib-modules/field_encrypt/issues/21

Adds an overview page of all encrypted fields on the current site, and a link to decrypt the field.
The decryption is run through the same batch process as when field storage settings are updated.
